### PR TITLE
bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(options) {
       // handle text field data
       busboy.on('field', function(fieldname, val, valTruncated, keyTruncated) {
         if (req.body.hasOwnProperty(fieldname)) {
-          if (Array.isArray(req.body)) {
+          if (Array.isArray(req.body[fieldname])) {
             req.body[fieldname].push(val);
           } else {
             req.body[fieldname] = [req.body[fieldname], val];


### PR DESCRIPTION
corrects for encodedUrl "&foo=bar1&foo=bar2&foo=bar3&foo=bar4" 
 ==> foo: [ [ [ 'bar1', 'bar2' ], 'bar3' ], 'bar4' ]
by
==> foo: [  'bar1', 'bar2' , 'bar3', 'bar4' ]
