### PR TITLE
Added size of the uploaded file to the file object in the request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A multer file object is a JSON object with the following properties.
 5. `mimetype` - Mime type of the file
 6. `path` - Location of the uploaded file
 7. `extension` - Extension of the file
+8. `size` - Size of the file in bytes
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -80,7 +80,8 @@ module.exports = function(options) {
           encoding: encoding,
           mimetype: mimetype,
           path: newFilePath,
-          extension: (ext === null) ? null : ext.replace('.', '')
+          extension: (ext === null) ? null : ext.replace('.', ''),
+          size: 0
         };
 
         // trigger "file upload start" event
@@ -90,6 +91,7 @@ module.exports = function(options) {
         fileStream.pipe(ws);
 
         fileStream.on('data', function(data) {
+          if (data) { file.size += data.length; }
           // trigger "file data" event
           if (options.onFileUploadData) { options.onFileUploadData(file, data); }
         });


### PR DESCRIPTION
I often have use for the length of the file uploaded, and previously have been calculating it in onFileUploadData and onFileUploadStart.  This eliminates the need to do so with very little added cost to execution.
