### PR TITLE
Support busboy truncated flag for files that exceed fileSize limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ module.exports = function(options) {
           encoding: encoding,
           mimetype: mimetype,
           path: newFilePath,
+          truncated: null,
           extension: (ext === null) ? null : ext.replace('.', '')
         };
 
@@ -95,6 +96,7 @@ module.exports = function(options) {
         });
 
         fileStream.on('end', function() {
+          file.truncated = fileStream.truncated;
           req.files[fieldname] = file;
           // trigger "file end" event
           if (options.onFileUploadComplete) { options.onFileUploadComplete(file); }


### PR DESCRIPTION
From the busboy [README](https://github.com/mscdex/busboy/blob/master/README.md):

> `stream` also has a boolean property 'truncated', which indicates if the file stream was truncated because a configured file size limit was reached. It's probably best to check this value at the end of the stream.
