### PR TITLE
Allow support for file input 'multiple' attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,14 @@ module.exports = function(options) {
         });
 
         fileStream.on('end', function() {
-          req.files[fieldname] = file;
+          if (req.files[fieldname]) {
+            if (!Array.isArray(req.files[fieldname])) {
+              req.files[fieldname] = [ req.files[fieldname] ];
+            }
+            req.files[fieldname].push(file);
+          } else {
+            req.files[fieldname] = file;
+          }
           // trigger "file end" event
           if (options.onFileUploadComplete) { options.onFileUploadComplete(file); }
         });


### PR DESCRIPTION
Addresses https://github.com/expressjs/multer/issues/15

This may or may not be the desired behavior, but in an effort to keep backward compatibility...

For a file input named `foo`, when a single file is uploaded:

``` javascript
req.files: {
  foo: {
    fieldname: 'foo',
    originalname: 'foo.jpg',
    name: '7a1cc501a983e4cdaa2e50430ca1c800.jpg',
    encoding: '7bit',
    mimetype: 'image/jpeg',
    path: '/tmp/7a1cc501a983e4cdaa2e50430ca1c800.jpg',
    extension: 'jpg',
    size: 68004 
  } 
}
```

And for a file input named `foo` with `multiple` attribute, when 2 files are uploaded:

``` javascript
req.files: { 
  foo: [
   { fieldname: 'foo',
     originalname: 'foo1.png',
     name: '3d57d1279bc5cf871984c114106d7a81.png',
     encoding: '7bit',
     mimetype: 'image/png',
     path: '/tmp/3d57d1279bc5cf871984c114106d7a81.png',
     extension: 'png',
     size: 39787,
     truncated: false },
   { fieldname: 'foo',
     originalname: 'foo2.jpg',
     name: '3a33f375ef176096d89758d8b3771ca2.jpg',
     encoding: '7bit',
     mimetype: 'image/jpeg',
     path: '/tmp/3a33f375ef176096d89758d8b3771ca2.jpg',
     extension: 'jpg',
     size: 47484,
     truncated: false } 
  ] 
}
```
