### PR TITLE
Allow to cancel upload onFileUploadStart

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,13 @@ module.exports = function(options) {
         };
 
         // trigger "file upload start" event
-        if (options.onFileUploadStart) { options.onFileUploadStart(file); }
+        if (options.onFileUploadStart) {
+          var cancelMaybe = options.onFileUploadStart(file);
+          if (typeof cancelMaybe == "object" && cancelMaybe && cancelMaybe.cancel) {
+            fileStream.resume();
+            return;
+          }
+        }
 
         var ws = fs.createWriteStream(newFilePath);
         fileStream.pipe(ws);


### PR DESCRIPTION
It would be interesting to be able to filter files that we want uploaded or that we don't. For example, only allow files from fieldnames that are in the form we want files to be uploaded from.

This pull request offers that possibility. Returning {cancel: true} in the onFileUploadStart function cancels the file upload ; the file will not be written on the disc and will not appear in req.files.

I am open to any suggestions, I might be too careful in checking that the return value is really of the right type, and my variable name for that return value isn't that great.

If you agree on the design, I will edit the documentation to add that feature inside it.
