### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "mkdirp": "~0.3.5",
-    "busboy": "^0.2.6"
+    "busboy": ">=0.2.6"
   },
   "devDependencies": {
     "connect": "*",


### PR DESCRIPTION
Currently returns the error

```
Error: No compatible version found: busboy@'^0.2.6'
```

due to 0.2.6 being the version, ^ doesn't include this.
