### PR TITLE
Updated to busboy 0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "mkdirp": "~0.3.5",
-    "busboy": "^0.2.6"
+    "busboy": "^0.2.7"
   },
   "devDependencies": {
     "connect": "*",


### PR DESCRIPTION
Contains major bugfix => multipart: add workaround for joyent/node@2efe4ab
