### PR TITLE
Add the request as argument to the function onParseEnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,16 @@ onParseStart: function () {
 }
 ```
 
-### onParseEnd()
+### onParseEnd(req)
 
-Event handler triggered when the form parsing completes.
+Event handler triggered when the form parsing completes. The request is available to the function.
 
 ```js
-onParseStart: function () {
+onParseStart: function (req) {
   console.log('Form parsing completed at: ', new Date())
+
+  // custom body parse
+  req.body = require('qs').parse(req.body)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ module.exports = function(options) {
           }
         }
         // when done parsing the form, pass the control to the next middleware in stack
-        if (options.onParseEnd) { options.onParseEnd(); }
+        if (options.onParseEnd) { options.onParseEnd(req); }
         next();
       });
 


### PR DESCRIPTION
This allows easier extensibility (e.g. use a custom body parse). 
