### PR TITLE
Prevent loosing empty strings in arrays when includeEmptyFields set to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function(options) {
         // attach the fields to req.body
         if (!options.includeEmptyFields && !val) return;
 
-        if (req.body.hasOwnProperty(fieldname) && val) {
+        if (req.body.hasOwnProperty(fieldname)) {
           if (Array.isArray(req.body[fieldname])) {
             req.body[fieldname].push(val);
           } else {


### PR DESCRIPTION
For example, when I'm sending an array ['a', 'b', ''], the entire field would become empty because in the last handler for '' it will straight away go into: `req.body[fieldname] = val;` and thus empty.

Here I also feel that `includeEmptyFields` should not be handled in the `on field` event, it should be handled after the parsing is done, then remove potential empty fields. I might not want empty fields, but I might still want ['a', 'b', ''] to be accepted (albeit as ['a', 'b'].
