### PR TITLE
Include request, response objects in arguments to onFileUploadStart etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = function(options) {
 
         // trigger "file upload start" event
         if (options.onFileUploadStart) {
-          var proceed = options.onFileUploadStart(file);
+          var proceed = options.onFileUploadStart(file, req, res);
           // if the onFileUploadStart handler returned null, it means we should proceed further, discard the file!
           if (proceed == false) {
             fileCount--;
@@ -120,7 +120,7 @@ module.exports = function(options) {
             file.size += data.length; 
           }
           // trigger "file data" event
-          if (options.onFileUploadData) { options.onFileUploadData(file, data); }
+          if (options.onFileUploadData) { options.onFileUploadData(file, data, req, res); }
         });
 
         function onFileStreamEnd() {
@@ -130,7 +130,7 @@ module.exports = function(options) {
           req.files[fieldname].push(file);
 
           // trigger "file end" event
-          if (options.onFileUploadComplete) { options.onFileUploadComplete(file); }
+          if (options.onFileUploadComplete) { options.onFileUploadComplete(file, req, res); }
 
           // defines has completed processing one more file
           fileCount--;


### PR DESCRIPTION
This PR is similar to #50 but is more generally useful because it passes both the request and response objects to the onFileUploadStart, onFileUploadData, onFileUploadComplete functions.

The main motivation for doing this is to allow progressive responses to be sent to the client (via either http or socket.io) as the upload is received. Access to the request object allows identifying info about the request to be read; access to the response object allows progress data to be sent to the client over http.

The new arguments are additional to the existing file + data args, so the change is backwards compatible.