### PR TITLE
Cleaner extension split and fix for redundant ext null check

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,7 @@ module.exports = function(options) {
         // defines is processing a new file
         fileCount++;
 
-        if (filename.indexOf('.') > 0) { ext = '.' + filename.split('.').slice(-1)[0]; }
-        else { ext = ''; }
+        ext = filename.indexOf('.') > 0 ? '.' + filename.split('.').pop() : '';
 
         newFilename = rename(fieldname, filename.replace(ext, '')) + ext;
         newFilePath = path.join(dest, newFilename);
@@ -90,7 +89,7 @@ module.exports = function(options) {
           encoding: encoding,
           mimetype: mimetype,
           path: newFilePath,
-          extension: (ext === null) ? null : ext.replace('.', ''),
+          extension: ext === '' ? null : ext.replace('.', ''),
           size: 0,
           truncated: null,
           buffer: null


### PR DESCRIPTION
Nothing major. I changed the .slice(-1)[0] to .pop(), it seems cleaner. 

Also, the variable ext is checked === null, which is never the case as it is always set to be some string. I've changed the conditional check so null will be returned if ext was empty. The conditional check can be removed completely to retain the current behavior: empty string when no extension is present.