### PR TITLE
Grammar changes to the onFileUploadStart function documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ rename: function (fieldname, filename) {
 
 ### onFileUploadStart(file)
 
-Event handler triggered when a file starts to be uploaded. A file object with the following properties is available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, and `extension`.
+Event handler triggered when a file starts to be uploaded. A file object, with the following properties, is available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, and `extension`.
 
 ```js
 onFileUploadStart: function (file) {

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ rename: function (fieldname, filename) {
 
 ### onFileUploadStart(file)
 
-Event handler triggered when a file starts to be uploaded. A file object with the following properties are available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, and `extension`.
+Event handler triggered when a file starts to be uploaded. A file object with the following properties is available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, and `extension`.
 
 ```js
 onFileUploadStart: function (file) {

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ rename: function (fieldname, filename) {
 
 ### onFileUploadStart(file)
 
-Event handler triggered when a file starts to be uploaded. A file object with the following properties are available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, `extension`.
+Event handler triggered when a file starts to be uploaded. A file object with the following properties are available to this function: `fieldname`, `originalname`, `name`, `encoding`, `mimetype`, `path`, and `extension`.
 
 ```js
 onFileUploadStart: function (file) {


### PR DESCRIPTION
"Changed the grammar on line 142 by adding an 'and' after the penultimate element in the list, by adding two commas, and by changing the 'are' to 'is' for referencing the file object. I believe this makes the documentation more readable and avoids a little confusion."