### PR TITLE
package: node 0.8.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
+  - "0.8"
   - "0.10"
   - "0.12"
+before_install:
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "testdata-w3c-json-form": "^0.2.0"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.8.0"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
I don't see any reason not to support Node.js 0.8.x, even if it's quite old. If the Travis tests pass without issues I think we should merge this one.