### PR TITLE
Update make-middleware.js. Object.create(null) => Object.create(Object.prototype)

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -25,7 +25,7 @@ function makeMiddleware (setup) {
       default: throw new Error('Unknown file strategy: ' + fileStrategy)
     }
 
-    req.body = Object.create(null)
+    req.body = Object.create(Object.prototype)
 
     var busboy = new Busboy({ headers: req.headers, limits: limits })
     var isDone = false


### PR DESCRIPTION
The problem is when you are using Object.create(null), JS created absolutely null object without inherited properties even from Object.prototype. So for Body object it is critical as we can't use (for example) hasOwnProperty method as below:

            if ( req.body.hasOwnProperty(field) && Model.schema.path(field) ) {
                model[ field ] = req.body[ field ];
            }

More info here: http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull