### PR TITLE
Add .matches()

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ Example:
 ]
 ```
 
+#### `.matches(regex[, maxCount])
+
+Accept a mix of files with names matching a regular expression. Optionally error
+out if more than `maxCount` files are uploaded. An object with arrays of files
+will be stored in `req.files`.
+
+For example, you might use `/^pdf_upload_\d+$/` if you have a dynamic form that
+needs to assocate numbered fields with files in a manner not guaranteed by
+browser field/upload ordering.
+
 ### `storage`
 
 #### `DiskStorage`

--- a/test/expected-files.js
+++ b/test/expected-files.js
@@ -94,4 +94,47 @@ describe('Expected files', function () {
       done()
     })
   })
+
+  it('should accept files with matching fieldnames', function (done) {
+    var form = new FormData()
+    var parser = upload.matches(/^butme_\d$/, 5)
+
+    form.append('butme_0', util.file('small0.dat'))
+    form.append('butme_1', util.file('small1.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.files['butme_0'][0].originalname, 'small0.dat')
+      assert.equal(req.files['butme_1'][0].originalname, 'small1.dat')
+      done()
+    })
+  })
+
+  it('should reject files with non-matching fieldnames', function (done) {
+    var form = new FormData()
+    var parser = upload.matches(/^butme_\d$/, 5)
+
+    form.append('notme_0', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.equal(err.field, 'notme_0')
+      done()
+    })
+  })
+
+  it('should reject too many files with matching fieldnames', function (done) {
+    var form = new FormData()
+    var parser = upload.matches(/^butme_\d$/, 1)
+
+    form.append('butme_0', util.file('small0.dat'))
+    form.append('butme_1', util.file('small1.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.equal(err.field, 'butme_1')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This allows people to use dynamic forms that may generate fields with
regular names, such as clicking "Add row" and getting a new field named
`description_47` and `file_upload_47`.