### PR TITLE
add support for cases where there we don't know exactly which files will be submitted and how many

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,12 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
     })
 
     function wrappedFileFilter (req, file, cb) {
-      if (fields[0].name != undefined ){
-	if ((filesLeft[file.fieldname] || 0) <= 0) {
-		return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
-	}
+      if (fields[0].name !== undefined ){
+        if ((filesLeft[file.fieldname] || 0) <= 0) {
+          return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
+        }
 
-	filesLeft[file.fieldname] -= 1
+        filesLeft[file.fieldname] -= 1
       }
       fileFilter(req, file, cb)
     }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
 
     function wrappedFileFilter (req, file, cb) {
       // in case user does not know in advance the file types that will be sent over
-      if (fields[0].name !== undefined){
+      if (fields[0].name !== undefined) {
         if ((filesLeft[file.fieldname] || 0) <= 0) {
           return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
         }

--- a/index.js
+++ b/index.js
@@ -35,11 +35,13 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
     })
 
     function wrappedFileFilter (req, file, cb) {
-      if ((filesLeft[file.fieldname] || 0) <= 0) {
-        return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
-      }
+      if (fields[0].name != undefined ){
+	if ((filesLeft[file.fieldname] || 0) <= 0) {
+		return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
+	}
 
-      filesLeft[file.fieldname] -= 1
+	filesLeft[file.fieldname] -= 1
+      }
       fileFilter(req, file, cb)
     }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
     })
 
     function wrappedFileFilter (req, file, cb) {
-      if (fields[0].name !== undefined ){
+      // in case user does not know in advance the file types that will be sent over
+      if (fields[0].name !== undefined){
         if ((filesLeft[file.fieldname] || 0) <= 0) {
           return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
         }


### PR DESCRIPTION
adde support to cases where we don’t know which files types will be sent and how many.