### PR TITLE
Added encryptStorage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ memory storage is used.
 
 #### `EncryptStorage`
 
-The encryption storage engine encrypts files using AES-256-XTS with 32bytes of
+The encryption storage engine encrypts files using AES-256-GCM with 32bytes of
 random data.
 
 ```javascript
@@ -224,6 +224,8 @@ It has 2 options available: `destination`, `filename`. Both
 
 A hexidecimal representation of the encryption key is added to
 `req.files.encryptionKey`.
+
+A buffer comprising of the authentication tag is added to `req.files.tag`
 
 ### `limits`
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,33 @@ When using memory storage, the file info will contain a field called
 numbers very quickly, can cause your application to run out of memory when
 memory storage is used.
 
+#### `EncryptStorage`
+
+The encryption storage engine encrypts files using AES-256-XTS with 32bytes of
+random data.
+
+```javascript
+var storage = multer.encryptStorage({
+  memory_only: true
+  destination: function (req, file, cb) {
+    cb(null, '/tmp/my-uploads')
+  },
+  filename: function (req, file, cb) {
+    cb(null, file.fieldname + '-' + Date.now())
+  }
+})
+
+var upload = multer({ storage: storage })
+```
+It has 3 options available: `destination`, `filename` and `memory_only`. Both
+`destination` and `filename` does the same as they do for `DiskStorage`. The
+`memory_only` option takes a boolean (Defaults to false if omitted) and defines
+wether or not the file should be stored in memory. You might have to experiment
+with this, as the **WARNING** from `MemoryStorage` applies here aswell.
+
+A hexidecimal representation of the encryption key is added to
+`req.files.encryptionKey`.
+
 ### `limits`
 
 An object specifying the size limits of the following optional properties. Multer passes this object into busboy directly, and the details of the properties can be found on [busboy's page](https://github.com/mscdex/busboy#busboy-methods).

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ random data.
 
 ```javascript
 var storage = multer.encryptStorage({
-  memory_only: true
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -220,11 +219,8 @@ var storage = multer.encryptStorage({
 
 var upload = multer({ storage: storage })
 ```
-It has 3 options available: `destination`, `filename` and `memory_only`. Both
-`destination` and `filename` does the same as they do for `DiskStorage`. The
-`memory_only` option takes a boolean (Defaults to false if omitted) and defines
-wether or not the file should be stored in memory. You might have to experiment
-with this, as the **WARNING** from `MemoryStorage` applies here aswell.
+It has 2 options available: `destination`, `filename`. Both
+`destination` and `filename` does the same as they do for `DiskStorage`.
 
 A hexidecimal representation of the encryption key is added to
 `req.files.encryptionKey`.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var makeMiddleware = require('./lib/make-middleware')
 
 var diskStorage = require('./storage/disk')
 var memoryStorage = require('./storage/memory')
+var encryptStorage = require('./storage/encrypt')
 
 function allowAll (req, file, cb) {
   cb(null, true)
@@ -94,3 +95,4 @@ function multer (options) {
 module.exports = multer
 module.exports.diskStorage = diskStorage
 module.exports.memoryStorage = memoryStorage
+module.exports.encryptStorage = encryptStorage

--- a/storage/encrypt.js
+++ b/storage/encrypt.js
@@ -37,14 +37,13 @@ EncryptStorage.prototype._handleFile = function _handleFile (req, file, cb) {
     that.getFilename(req, file, function (err, filename) {
       if (err) return cb(err)
 
-
       var finalPath = path.join(destination, filename)
       var key = crypto.randomBytes(32).toString('hex')
-      var cipher = crypto.createCipher('aes-256-xts', key);
+      var cipher = crypto.createCipher('aes-256-xts', key)
       if (that.memory_only) {
         var outMemStream = fs.createWriteStream(finalPath)
         file.stream.pipe(cipher).pipe(outMemStream)
-        outMemStream.on('finish', function() {
+        outMemStream.on('finish', function () {
           cb(null, {
             destination: destination,
             filename: filename,
@@ -53,18 +52,17 @@ EncryptStorage.prototype._handleFile = function _handleFile (req, file, cb) {
             size: outMemStream.bytesWritten
           })
         })
-      }
-      else {
-        var outStream = fs.createWriteStream(finalPath+'.tmp.original')
+      } else {
+        var outStream = fs.createWriteStream(finalPath + '.tmp.original')
         file.stream.pipe(outStream)
         outStream.on('error', cb)
         outStream.on('finish', function () {
-          var input = fs.createReadStream(finalPath+'.tmp.original')
-          var output = fs.createWriteStream(finalPath);
+          var input = fs.createReadStream(finalPath + '.tmp.original')
+          var output = fs.createWriteStream(finalPath)
 
-          input.pipe(cipher).pipe(output);
-          output.on('finish', function() {
-            fs.unlink(finalPath+'.tmp.original', function() {
+          input.pipe(cipher).pipe(output)
+          output.on('finish', function () {
+            fs.unlink(finalPath + '.tmp.original', function () {
               cb(null, {
                 destination: destination,
                 filename: filename,

--- a/storage/encrypt.js
+++ b/storage/encrypt.js
@@ -1,0 +1,95 @@
+// jshint asi:true
+
+var fs = require('fs')
+var os = require('os')
+var path = require('path')
+var crypto = require('crypto')
+var mkdirp = require('mkdirp')
+
+function getFilename (req, file, cb) {
+  crypto.pseudoRandomBytes(16, function (err, raw) {
+    cb(err, err ? undefined : raw.toString('hex'))
+  })
+}
+
+function getDestination (req, file, cb) {
+  cb(null, os.tmpdir())
+}
+
+function EncryptStorage (opts) {
+  this.getFilename = (opts.filename || getFilename)
+
+  if (typeof opts.destination === 'string') {
+    mkdirp.sync(opts.destination)
+    this.getDestination = function ($0, $1, cb) { cb(null, opts.destination) }
+  } else {
+    this.getDestination = (opts.destination || getDestination)
+  }
+  this.memory_only = (opts.memory_only || false)
+}
+
+EncryptStorage.prototype._handleFile = function _handleFile (req, file, cb) {
+  var that = this
+
+  that.getDestination(req, file, function (err, destination) {
+    if (err) return cb(err)
+
+    that.getFilename(req, file, function (err, filename) {
+      if (err) return cb(err)
+
+
+      var finalPath = path.join(destination, filename)
+      var key = crypto.randomBytes(32).toString('hex')
+      var cipher = crypto.createCipher('aes-256-xts', key);
+      if (that.memory_only) {
+        var outMemStream = fs.createWriteStream(finalPath)
+        file.stream.pipe(cipher).pipe(outMemStream)
+        outMemStream.on('finish', function() {
+          cb(null, {
+            destination: destination,
+            filename: filename,
+            path: finalPath,
+            encryptionKey: key,
+            size: outMemStream.bytesWritten
+          })
+        })
+      }
+      else {
+        var outStream = fs.createWriteStream(finalPath+'.tmp.original')
+        file.stream.pipe(outStream)
+        outStream.on('error', cb)
+        outStream.on('finish', function () {
+          var input = fs.createReadStream(finalPath+'.tmp.original')
+          var output = fs.createWriteStream(finalPath);
+
+          input.pipe(cipher).pipe(output);
+          output.on('finish', function() {
+            fs.unlink(finalPath+'.tmp.original', function() {
+              cb(null, {
+                destination: destination,
+                filename: filename,
+                path: finalPath,
+                encryptionKey: key,
+                size: outStream.bytesWritten
+              })
+            })
+          })
+        })
+      }
+    })
+  })
+}
+
+EncryptStorage.prototype._removeFile = function _removeFile (req, file, cb) {
+  var path = file.path
+
+  delete file.destination
+  delete file.filename
+  delete file.path
+
+  fs.unlink(path, cb)
+}
+
+module.exports = function (opts) {
+  return new EncryptStorage(opts)
+}

--- a/storage/encrypt.js
+++ b/storage/encrypt.js
@@ -40,7 +40,7 @@ EncryptStorage.prototype._handleFile = function _handleFile (req, file, cb) {
       crypto.randomBytes(32, function (err, buf) {
         if (err) return cb(err)
         var key = buf.toString('hex')
-        var cipher = crypto.createCipher('aes-256-xts', key)
+        var cipher = crypto.createCipher('aes-256-gcm', key)
         var outMemStream = fs.createWriteStream(finalPath)
         file.stream.pipe(cipher).pipe(outMemStream)
         outMemStream.on('error', cb)
@@ -50,6 +50,7 @@ EncryptStorage.prototype._handleFile = function _handleFile (req, file, cb) {
             filename: filename,
             path: finalPath,
             encryptionKey: key,
+            tag: cipher.getAuthTag(),
             size: outMemStream.bytesWritten
           })
         })


### PR DESCRIPTION
Added support for encryptStorage module and added it to the README.

It uses crypto.createCipher() using the 'AES-256-XTS cipher, with a 36 byte binary key, derived from cypto.randomBytes(). The key is returned to the client in the req.files.encryptKey as a hex string.

With the memory_only boolean (defaults to false) you'll decide to temporarily write to disk before encryption or not.

I'll do some more work on it hopefully verifying that randomBytes actually is a CPRNG, and maybe change it to createCipheriv().

As it is now, it works, and is reasonably secure.

Haven't updated the CHANGELOG or version number.
