### PR TITLE
maintain object prototype chain for req.body

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -24,7 +24,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
 
-    req.body = Object.create(null)
+    req.body = Object.create(Object.prototype)
 
     var busboy
 


### PR DESCRIPTION
This changes `req.body` to include Object in the prototype.

The `req.body` object provided by expressjs has `Object` in the prototype chain but multer creates an object with no prototype. For code that expects `hasOwnProperty` or another `Object` member, I need to manually set the prototype myself or create a shallow copy to something with `Object` in its chain. 