### PR TITLE
expose busboy options for #320

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function Multer (options) {
   }
 
   this.limits = options.limits
+  this.highWaterMark = options.highWaterMark
+  this.fileHwm = options.fileHwm
+  this.defCharset = options.defCharset
+  this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
 }
 
@@ -45,6 +49,10 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
 
     return {
       limits: this.limits,
+      highWaterMark: this.highWaterMark,
+      fileHwm: this.fileHwm,
+      defCharset: this.defCharset,
+      preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
       fileStrategy: fileStrategy
@@ -70,6 +78,10 @@ Multer.prototype.any = function () {
   function setup () {
     return {
       limits: this.limits,
+      highWaterMark: this.highWaterMark,
+      fileHwm: this.fileHwm,
+      defCharset: this.defCharset,
+      preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: this.fileFilter,
       fileStrategy: 'ARRAY'

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -29,7 +29,14 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits })
+      busboy = new Busboy({
+        headers: req.headers,
+        limits: limits,
+        highWaterMark: options.highWaterMark,
+        fileHwm: options.fileHwm,
+        defCharset: options.defCharset,
+        preservePath: options.preservePath
+      })
     } catch (err) {
       return next(err)
     }


### PR DESCRIPTION
I just followed the module's code style and explicitly specified all the busboy options (but my personal preference would be to just give busboy the options object the user passes with any multer generated options merged in, that way if busboy adds new options, no multer code needs to be changed).
