### PR TITLE
#211 Add a transformFile option

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function allowAll (req, file, cb) {
   cb(null, true)
 }
 
+function defaultTransformFile (req, file, cb) {
+  return cb(null, file)
+}
+
 function Multer (options) {
   if (options.storage) {
     this.storage = options.storage
@@ -19,6 +23,7 @@ function Multer (options) {
 
   this.limits = options.limits
   this.fileFilter = options.fileFilter || allowAll
+  this.transformFile = options.transformFile || defaultTransformFile
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -47,7 +52,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       limits: this.limits,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      transformFile: this.transformFile
     }
   }
 
@@ -72,7 +78,8 @@ Multer.prototype.any = function () {
       limits: this.limits,
       storage: this.storage,
       fileFilter: this.fileFilter,
-      fileStrategy: 'ARRAY'
+      fileStrategy: 'ARRAY',
+      transformFile: this.transformFile
     }
   }
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -126,6 +126,7 @@ function makeMiddleware (setup) {
         Object.defineProperty(file, 'stream', {
           configurable: true,
           enumerable: false,
+          writable: true,
           value: fileStream
         })
 
@@ -139,25 +140,33 @@ function makeMiddleware (setup) {
           abortWithCode('LIMIT_FILE_SIZE', fieldname)
         })
 
-        storage._handleFile(req, file, function (err, info) {
-          if (aborting) {
-            appender.removePlaceholder(placeholder)
-            uploadedFiles.push(extend(file, info))
-            return pendingWrites.decrement()
-          }
-
+        options.transformFile(req, file, function (err, newFile) {
           if (err) {
             appender.removePlaceholder(placeholder)
             pendingWrites.decrement()
             return abortWithError(err)
           }
 
-          var fileInfo = extend(file, info)
+          storage._handleFile(req, newFile, function (err, info) {
+            if (aborting) {
+              appender.removePlaceholder(placeholder)
+              uploadedFiles.push(extend(newFile, info))
+              return pendingWrites.decrement()
+            }
 
-          appender.replacePlaceholder(placeholder, fileInfo)
-          uploadedFiles.push(fileInfo)
-          pendingWrites.decrement()
-          indicateDone()
+            if (err) {
+              appender.removePlaceholder(placeholder)
+              pendingWrites.decrement()
+              return abortWithError(err)
+            }
+
+            var fileInfo = extend(newFile, info)
+
+            appender.replacePlaceholder(placeholder, fileInfo)
+            uploadedFiles.push(fileInfo)
+            pendingWrites.decrement()
+            indicateDone()
+          })
         })
 
       })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "mocha": "^2.2.5",
     "rimraf": "^2.4.1",
     "standard": "^4.5.4",
-    "testdata-w3c-json-form": "^0.2.0"
+    "testdata-w3c-json-form": "^0.2.0",
+    "through2": "^2.0.1"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/test/transform-file.js
+++ b/test/transform-file.js
@@ -1,0 +1,63 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+var through2 = require('through2')
+
+describe('Transform File', function () {
+  it('transfrom the file contents', function (done) {
+    var form = new FormData()
+    var upload = multer({
+      storage: multer.memoryStorage(),
+      transformFile: function (req, file, cb) {
+        // Transforms the stream by changing the first < to >
+        var origStream = file.stream
+        file.stream = through2(function (buf, enc, done) {
+          done(null, new Buffer(buf.toString().replace('<', '>')))
+        })
+        origStream.pipe(file.stream)
+        cb(null, file)
+      }
+	})
+    var parser = upload.single('tiny1')
+    form.append('tiny1', util.file('tiny1.dat'))
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.file.fieldname, 'tiny1')
+      assert.equal(req.file.originalname, 'tiny1.dat')
+      assert.equal(req.file.size, 7)
+      assert.equal(req.file.buffer.length, 7)
+      assert.equal(req.file.buffer.toString(), '>o)))<<')
+
+      done()
+    })
+  })
+
+  it('transfrom the file properties', function (done) {
+    var form = new FormData()
+    var upload = multer({
+      storage: multer.memoryStorage(),
+      transformFile: function (req, file, cb) {
+        file.originalname = 'tiny1.txt'
+        cb(null, file)
+      }
+	})
+    var parser = upload.single('tiny1')
+    form.append('tiny1', util.file('tiny1.dat'))
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.file.fieldname, 'tiny1')
+      assert.equal(req.file.originalname, 'tiny1.txt')
+      assert.equal(req.file.size, 7)
+      assert.equal(req.file.buffer.length, 7)
+      assert.equal(req.file.buffer.toString(), '<o)))<<')
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This is obviously not a PR ready for merging.  But I wanted to post it to get the discussion started.  Before I write tests and docs, is there anything inherently wrong with the approach I took on this?  Is there any problem with not handling the `fileStream` events?  Or would that be up to the implementor of the transform method?

This is an example of how I saw this working from a users perspective:

``` javascript
var upload = multer({
  transformFile: function (req, file, cb) {
    file.stream = pump(file.stream, resizeMyImage(file), saveMyImageSomewhereElse(file))
    // Optionally change other parts of the file object...
    cb(null, file)
  }
})
```

Thoughts? Feedback before I write tests to make sure it all works correctly?
