### PR TITLE
Closes #278

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Example:
 ]
 ```
 
+#### `.none()`
+
+Accept only text fields. If any file upload is made, error with code
+"LIMIT\_UNEXPECTED\_FILE" will be issued. This is the same as doing `upload.fields([])`.
+
 #### `.any()`
 
 Accepts all files that comes over the wire. An array of files will be stored in

--- a/index.js
+++ b/index.js
@@ -66,6 +66,10 @@ Multer.prototype.fields = function (fields) {
   return this._makeMiddleware(fields, 'OBJECT')
 }
 
+Multer.prototype.none = function () {
+  return this.fields([], 'OBJECT')
+}
+
 Multer.prototype.any = function () {
   function setup () {
     return {

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Multer.prototype.fields = function (fields) {
 }
 
 Multer.prototype.none = function () {
-  return this.fields([], 'OBJECT')
+  return this._makeMiddleware([], 'NONE')
 }
 
 Multer.prototype.any = function () {

--- a/lib/file-appender.js
+++ b/lib/file-appender.js
@@ -10,6 +10,7 @@ function FileAppender (strategy, req) {
   this.req = req
 
   switch (strategy) {
+    case 'NONE': break
     case 'VALUE': break
     case 'ARRAY': req.files = []; break
     case 'OBJECT': req.files = Object.create(null); break
@@ -23,6 +24,7 @@ FileAppender.prototype.insertPlaceholder = function (file) {
   }
 
   switch (this.strategy) {
+    case 'NONE': break
     case 'VALUE': break
     case 'ARRAY': this.req.files.push(placeholder); break
     case 'OBJECT':
@@ -39,6 +41,7 @@ FileAppender.prototype.insertPlaceholder = function (file) {
 
 FileAppender.prototype.removePlaceholder = function (placeholder) {
   switch (this.strategy) {
+    case 'NONE': break
     case 'VALUE': break
     case 'ARRAY': arrayRemove(this.req.files, placeholder); break
     case 'OBJECT':

--- a/test/none.js
+++ b/test/none.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+
+describe('None', function () {
+  var parser
+
+  before(function () {
+    parser = multer().none()
+  })
+
+  it('should not allow file uploads', function (done) {
+    var form = new FormData()
+
+    form.append('key1', 'val1')
+    form.append('key2', 'val2')
+    form.append('file', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      // "Unexpected field" error is expected
+      assert.ok(err)
+      assert.deepEqual(req.files, {})
+      assert.equal(req.body['key1'], 'val1')
+      assert.equal(req.body['key2'], 'val2')
+      done()
+    })
+  })
+})

--- a/test/none.js
+++ b/test/none.js
@@ -23,7 +23,7 @@ describe('None', function () {
     util.submitForm(parser, form, function (err, req) {
       // "Unexpected field" error is expected
       assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.deepEqual(req.files, {})
+      assert.equal(req.files, undefined)
       assert.equal(req.body['key1'], 'val1')
       assert.equal(req.body['key2'], 'val2')
       done()
@@ -38,7 +38,7 @@ describe('None', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.deepEqual(req.files, {})
+      assert.equal(req.files, undefined)
       assert.equal(req.body['key1'], 'val1')
       assert.equal(req.body['key2'], 'val2')
       done()

--- a/test/none.js
+++ b/test/none.js
@@ -22,7 +22,22 @@ describe('None', function () {
 
     util.submitForm(parser, form, function (err, req) {
       // "Unexpected field" error is expected
-      assert.ok(err)
+      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.deepEqual(req.files, {})
+      assert.equal(req.body['key1'], 'val1')
+      assert.equal(req.body['key2'], 'val2')
+      done()
+    })
+  })
+
+  it('should handle text fields', function (done) {
+    var form = new FormData()
+
+    form.append('key1', 'val1')
+    form.append('key2', 'val2')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
       assert.deepEqual(req.files, {})
       assert.equal(req.body['key1'], 'val1')
       assert.equal(req.body['key2'], 'val2')

--- a/test/none.js
+++ b/test/none.js
@@ -21,7 +21,7 @@ describe('None', function () {
     form.append('file', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      // "Unexpected field" error is expected
+      assert.ok(err)
       assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
       assert.equal(req.files, undefined)
       assert.equal(req.body['key1'], 'val1')


### PR DESCRIPTION
Implementation of #278.

Usage example:
```javascript
var express = require('express')
var multer  = require('multer')
var upload = multer({ dest: 'uploads/' })

var app = express()

app.post("/just-data", upload.none(), function (req, res) {
  // req.body will hold the text fields, if there were any
  // err expected in case of a file upload (https://github.com/expressjs/multer#error-handling)
})
```