### PR TITLE
Check and discard array notation from fieldname when fileStrategy is ARRAY

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
     })
 
     function wrappedFileFilter (req, file, cb) {
+      if (fileStrategy === 'ARRAY'){
+        // remove array notation: ex "file[0]" to "file"
+        file.fieldname = file.fieldname.replace(/\[\d\]/gi, '')
+      }
+
       if ((filesLeft[file.fieldname] || 0) <= 0) {
         return cb(makeError('LIMIT_UNEXPECTED_FILE', file.fieldname))
       }


### PR DESCRIPTION
I noticed angular.js was adding an array notation to the fieldname, and this check removes that. Not sure if this is valid or not but thought I would share since I'm sure others have come across this.
