### PR TITLE
Prevent Multiple Errors from Crashing

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -57,6 +57,7 @@ function makeMiddleware (setup) {
     }
 
     function abortWithError (uploadError) {
+      if (errorOccured) return
       errorOccured = true
 
       pendingWrites.onceZero(function () {

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -2,6 +2,7 @@
 
 var assert = require('assert')
 
+var os = require('os')
 var util = require('./_util')
 var multer = require('../')
 var stream = require('stream')
@@ -200,6 +201,22 @@ describe('Error Handling', function () {
 
     upload(req, null, function (err) {
       assert.equal(err.message, 'Unexpected end of multipart data')
+      done()
+    })
+  })
+
+  it('should gracefully handle more than one error at a time', function (done) {
+    var form = new FormData()
+    var storage = multer.diskStorage({ destination: os.tmpdir() })
+    var upload = multer({ storage: storage, limits: { fileSize: 1, files: 1 } }).fields([
+      { name: 'small0', maxCount: 1 }
+    ])
+
+    form.append('small0', util.file('small0.dat'))
+    form.append('small0', util.file('small0.dat'))
+
+    util.submitForm(upload, form, function (err, req) {
+      assert.equal(err.code, 'LIMIT_FILE_SIZE')
       done()
     })
   })


### PR DESCRIPTION
When you have an upload that has more than one error, seemingly only with disk storage, it causes the node process to crash. More details here - https://github.com/expressjs/multer/issues/335

```
Uncaught TypeError: path must be a string
```

Tests should showcase an example of this, along with a potential fix.
