### PR TITLE
Fix cleaning up temporary files on client abort.

### DIFF
--- a/lib/make-error.js
+++ b/lib/make-error.js
@@ -1,4 +1,5 @@
 var errorMessages = {
+  'CLIENT_ABORTED': 'Client aborted',
   'LIMIT_PART_COUNT': 'Too many parts',
   'LIMIT_FILE_SIZE': 'File too large',
   'LIMIT_FILE_COUNT': 'Too many files',

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -159,7 +159,10 @@ function makeMiddleware (setup) {
       })
     })
 
-    req.on('aborted', function () { abortWithCode('CLIENT_ABORTED') })
+    req.on('aborted', function () {
+      pendingWrites.decrement()
+      abortWithCode('CLIENT_ABORTED')
+    })
 
     busboy.on('error', function (err) { abortWithError(err) })
     busboy.on('partsLimit', function () { abortWithCode('LIMIT_PART_COUNT') })

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -140,7 +140,7 @@ function makeMiddleware (setup) {
           abortWithCode('LIMIT_FILE_SIZE', fieldname)
         })
 
-        storage._handleFile(req, file, function (err, info) {
+        storage._handleFile(req, file, function (err) {
           if (aborting) {
             appender.removePlaceholder(placeholder)
             return pendingWrites.decrement()

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -1,6 +1,5 @@
 var is = require('type-is')
 var Busboy = require('busboy')
-var extend = require('xtend')
 var onFinished = require('on-finished')
 var appendField = require('append-field')
 
@@ -123,6 +122,7 @@ function makeMiddleware (setup) {
 
         var aborting = false
         pendingWrites.increment()
+        uploadedFiles.push(file)
 
         Object.defineProperty(file, 'stream', {
           configurable: true,
@@ -143,7 +143,6 @@ function makeMiddleware (setup) {
         storage._handleFile(req, file, function (err, info) {
           if (aborting) {
             appender.removePlaceholder(placeholder)
-            uploadedFiles.push(extend(file, info))
             return pendingWrites.decrement()
           }
 
@@ -153,15 +152,14 @@ function makeMiddleware (setup) {
             return abortWithError(err)
           }
 
-          var fileInfo = extend(file, info)
-
-          appender.replacePlaceholder(placeholder, fileInfo)
-          uploadedFiles.push(fileInfo)
+          appender.replacePlaceholder(placeholder, file)
           pendingWrites.decrement()
           indicateDone()
         })
       })
     })
+
+    req.on('aborted', function () { abortWithCode('CLIENT_ABORTED') })
 
     busboy.on('error', function (err) { abortWithError(err) })
     busboy.on('partsLimit', function () { abortWithCode('LIMIT_PART_COUNT') })

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "mkdirp": "^0.5.1",
     "object-assign": "^3.0.0",
     "on-finished": "^2.3.0",
-    "type-is": "^1.6.4",
-    "xtend": "^4.0.0"
+    "type-is": "^1.6.4"
   },
   "devDependencies": {
     "express": "^4.13.1",

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -31,21 +31,21 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
   that.getDestination(req, file, function (err, destination) {
     if (err) return cb(err)
 
+    file.destination = destination
+
     that.getFilename(req, file, function (err, filename) {
       if (err) return cb(err)
 
-      var finalPath = path.join(destination, filename)
-      var outStream = fs.createWriteStream(finalPath)
+      file.filename = filename
+      file.path = path.join(destination, filename)
+
+      var outStream = fs.createWriteStream(file.path)
 
       file.stream.pipe(outStream)
       outStream.on('error', cb)
       outStream.on('finish', function () {
-        cb(null, {
-          destination: destination,
-          filename: filename,
-          path: finalPath,
-          size: outStream.bytesWritten
-        })
+        file.size = outStream.bytesWritten
+        cb(null)
       })
     })
   })

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -4,10 +4,9 @@ function MemoryStorage (opts) {}
 
 MemoryStorage.prototype._handleFile = function _handleFile (req, file, cb) {
   file.stream.pipe(concat(function (data) {
-    cb(null, {
-      buffer: data,
-      size: data.length
-    })
+    file.buffer = data
+    file.size = data.length
+    cb(null)
   }))
 }
 


### PR DESCRIPTION
I have an alternative solution to fix #259.

The advantage to this PR is that the user of the multer library will get a proper error object indicating the reason for the failure ("client aborted"). An advantageous side-effect of this PR is that it removes a dependency. I have also added a test to simulate the situation.

A downside of this PR is that it introduces breaking API changes (another error code that introduces behavioral changes) and I had to change the Storage API so that the Disk Storage can know which file to remove when an unfinished file is canceled.

If desired, I could add a check to see if the callback to `_handleFile()` still receives the second `info` parameter and if it does it could still extend the `file` object with it. That way we would need to bring back the `xtend` dependency, but it would make it even easier for any users to upgrade to the new version, as any existing custom Storage implementations *should* remain compatible.