### PR TITLE
Close request on file size limit reached. Fixes #344

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -136,6 +136,7 @@ function makeMiddleware (setup) {
         })
 
         fileStream.on('limit', function () {
+          fileStream.emit('close')
           aborting = true
           abortWithCode('LIMIT_FILE_SIZE', fieldname)
         })

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -38,15 +38,21 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
       var outStream = fs.createWriteStream(finalPath)
 
       file.stream.pipe(outStream)
+      file.stream.on('close', function () {
+        outStream.close()
+        onFinish()
+      })
       outStream.on('error', cb)
-      outStream.on('finish', function () {
+      outStream.on('finish', onFinish)
+      
+      function onFinish () {
         cb(null, {
           destination: destination,
           filename: filename,
           path: finalPath,
           size: outStream.bytesWritten
         })
-      })
+      }
     })
   })
 }

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -44,7 +44,7 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
       })
       outStream.on('error', cb)
       outStream.on('finish', onFinish)
-      
+
       function onFinish () {
         cb(null, {
           destination: destination,


### PR DESCRIPTION
Busboy only emits the 'limit' event. And even if it unpipes the multipart upload to ReadableStream file, it doesn't closes it.

This change emits the 'close' event so that the DiskStorage closes the WriteableStream to the temporal disk file and immediately calls the callback that allows the temp file to be removed and callbacks to express.

It uses outStream.close() instead of end() to maintain the convention that finish event should be upon full successful write only. Thus the cb is called.

Took about 4 hours to debug. But works.

One important thing to note is that if you are using a reverse proxy, buffering MUST be disabled and error 413 should be the response. Sending 400 wouldn't abort the request in nginx.