### PR TITLE
Pass the preservePath down to Busboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Key | Description
 `dest` or `storage` | Where to store the files
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
+`preservePath` | Keep the full path of files instead of just the base name
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function Multer (options) {
   }
 
   this.limits = options.limits
+  this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
 }
 
@@ -45,6 +46,7 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
 
     return {
       limits: this.limits,
+      preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
       fileStrategy: fileStrategy
@@ -74,6 +76,7 @@ Multer.prototype.any = function () {
   function setup () {
     return {
       limits: this.limits,
+      preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: this.fileFilter,
       fileStrategy: 'ARRAY'

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -23,13 +23,14 @@ function makeMiddleware (setup) {
     var storage = options.storage
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
+    var preservePath = options.preservePath
 
     req.body = Object.create(null)
 
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits })
+      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }


### PR DESCRIPTION
I'm working on a cloud compiler service that allows uploading files from a directory tree so it needs access to the entire path of each file that a user uploads.

There's a `preservePath` option in Busboy but it's not exposed in Multer so I added an option to Multer to allow preserving paths for uploaded files.