### PR TITLE
Add transform option and throttle test

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Key | Description
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
 `preservePath` | Keep the full path of files instead of just the base name
+`transform` | Pipe request through this stream before busboy
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
+  this.transform = options.transform
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,7 +50,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      transform: this.transform
     }
   }
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -24,6 +24,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var transform = options.transform
 
     req.body = Object.create(null)
 
@@ -46,7 +47,8 @@ function makeMiddleware (setup) {
       if (isDone) return
       isDone = true
 
-      req.unpipe(busboy)
+      if (transform) req.unpipe(transform)
+      else req.unpipe(busboy)
       drainStream(req)
       busboy.removeAllListeners()
 
@@ -173,7 +175,8 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
-    req.pipe(busboy)
+    if (transform) req.pipe(transform).pipe(busboy)
+    else req.pipe(busboy)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "mocha": "^2.2.5",
     "rimraf": "^2.4.1",
     "standard": "^8.2.0",
+    "stream-throttle": "^0.1.3",
     "testdata-w3c-json-form": "^0.2.0"
   },
   "engines": {

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+var Throttle = require('stream-throttle').Throttle
+
+describe('Transform stream', function () {
+  var bps = 1500000
+  var bytes = 2413677
+  var duration = bytes * 1000 / bps
+  this.timeout(1000 + duration)
+  var upload
+
+  before(function (done) {
+    upload = multer({
+      transform: new Throttle({rate: bps})
+    })
+    done()
+  })
+
+  it('should throttle file upload', function (done) {
+    var form = new FormData()
+    var start = Date.now()
+    var parser = upload.fields([
+      { name: 'large', maxCount: 1 }
+    ])
+
+    form.append('large', util.file('large.jpg'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.deepEqual(req.body, {})
+
+      assert.equal(req.files['large'][0].fieldname, 'large')
+      assert.equal(req.files['large'][0].originalname, 'large.jpg')
+      assert.equal(req.files['large'][0].size, bytes)
+      assert.equal(req.files['large'][0].buffer.length, bytes)
+      var interval = Date.now() - start
+      assert.ok(interval >= duration, 'Upload was too fast: ' + interval + ' < ' + duration)
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This adds the ability to transform stream before handing it to busboy.
It is particularly useful to throttle file uploads, as demonstrated in the test.
I needed this to be able to test my upload progress UI on localhost, but i suppose it could fit other purposes as well.