### PR TITLE
Avoid Stale when Callback Called Before Busboy Finished

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -54,7 +54,11 @@ function makeMiddleware (setup) {
     }
 
     function indicateDone () {
-      if (readFinished && pendingWrites.isZero() && !errorOccured) done()
+      if (readFinished && pendingWrites.isZero() && !errorOccured) {
+        done()
+      } else {
+        done(new Error('Callback is called before multer finished processing data!'))
+      }
     }
 
     function abortWithError (uploadError) {


### PR DESCRIPTION
Earlier, when StorageEngine's 'cb' callback of _handleFile()
is called before busboy finished its processing, the callback
to the client side is never called.