### PR TITLE
exceeded filesize Limit return value corrected to upper file Object

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -138,7 +138,7 @@ function makeMiddleware (setup) {
 
         fileStream.on('limit', function () {
           aborting = true
-          abortWithCode('LIMIT_FILE_SIZE', file)
+          abortWithCode('LIMIT_FILE_SIZE', fieldname, file)
         })
 
         storage._handleFile(req, file, function (err, info) {

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -140,7 +140,7 @@ function makeMiddleware (setup) {
           aborting = true
           abortWithCode('LIMIT_FILE_SIZE', fieldname, file)
         })
-
+        
         storage._handleFile(req, file, function (err, info) {
           if (aborting) {
             appender.removePlaceholder(placeholder)

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -140,7 +140,7 @@ function makeMiddleware (setup) {
           aborting = true
           abortWithCode('LIMIT_FILE_SIZE', fieldname, file)
         })
-        
+
         storage._handleFile(req, file, function (err, info) {
           if (aborting) {
             appender.removePlaceholder(placeholder)

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -138,7 +138,7 @@ function makeMiddleware (setup) {
 
         fileStream.on('limit', function () {
           aborting = true
-          abortWithCode('LIMIT_FILE_SIZE', fieldname)
+          abortWithCode('LIMIT_FILE_SIZE', file)
         })
 
         storage._handleFile(req, file, function (err, info) {

--- a/package.json
+++ b/package.json
@@ -19,23 +19,23 @@
     "middleware"
   ],
   "dependencies": {
-    "append-field": "^0.1.0",
-    "busboy": "^0.2.11",
-    "concat-stream": "^1.5.0",
+    "append-field": "^1.0.0",
+    "busboy": "^0.2.14",
+    "concat-stream": "^1.6.2",
     "mkdirp": "^0.5.1",
-    "object-assign": "^3.0.0",
+    "object-assign": "^4.1.1",
     "on-finished": "^2.3.0",
-    "type-is": "^1.6.4",
-    "xtend": "^4.0.0"
+    "type-is": "^1.6.16",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "express": "^4.13.1",
-    "form-data": "^1.0.0-rc1",
-    "fs-temp": "^0.1.2",
-    "mocha": "^2.2.5",
-    "rimraf": "^2.4.1",
-    "standard": "^8.2.0",
-    "testdata-w3c-json-form": "^0.2.0"
+    "express": "^4.16.3",
+    "form-data": "^2.3.2",
+    "fs-temp": "^1.1.2",
+    "mocha": "^5.2.0",
+    "rimraf": "^2.6.2",
+    "standard": "^11.0.1",
+    "testdata-w3c-json-form": "^0.2.1"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
in addition to https://github.com/expressjs/multer/issues/607
just changed fieldname to the file object, so that u have the choice, to do own errorhandling on exceeded filesize error.

This is very useful when you want to upload many files and don´t want to reject the hole array.
now You can inform the User which file was to large to upload, without rejecting the hole upload request.