### PR TITLE
Force req.file.buffer to always be a Buffer

### DIFF
--- a/storage/memory.js
+++ b/storage/memory.js
@@ -3,7 +3,7 @@ var concat = require('concat-stream')
 function MemoryStorage (opts) {}
 
 MemoryStorage.prototype._handleFile = function _handleFile (req, file, cb) {
-  file.stream.pipe(concat(function (data) {
+  file.stream.pipe(concat({ encoding: 'buffer' }, function (data) {
     cb(null, {
       buffer: data,
       size: data.length

--- a/test/memory-storage.js
+++ b/test/memory-storage.js
@@ -65,6 +65,7 @@ describe('Memory Storage', function () {
       assert.equal(req.file.originalname, 'empty.dat')
       assert.equal(req.file.size, 0)
       assert.equal(req.file.buffer.length, 0)
+      assert.equal(Buffer.isBuffer(req.file.buffer), true)
 
       done()
     })


### PR DESCRIPTION
Resolves issue #667 which is also discussed in #461 