### PR TITLE
tests: remove old Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
   - "8"
   - "10"


### PR DESCRIPTION
All versions prior Node.js 6 reached their EOL.

https://github.com/nodejs/Release/blob/master/README.md

If we increase the min version in package.json we should do this as part of a major release.