### PR TITLE
feat(form-data): Adds support for parsing regular blobs / non-file data (e.g. application/json)

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -3,6 +3,7 @@ var Busboy = require('busboy')
 var extend = require('xtend')
 var onFinished = require('on-finished')
 var appendField = require('append-field')
+var concat = require('concat-stream')
 
 var Counter = require('./counter')
 var MulterError = require('./multer-error')
@@ -24,6 +25,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var parseBlobs = options.parseBlobs
 
     req.body = Object.create(null)
 
@@ -95,7 +97,29 @@ function makeMiddleware (setup) {
     // handle files
     busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
       // don't attach to the files object, if there is no file
-      if (!filename) return fileStream.resume()
+      if (!filename || (parseBlobs && filename === 'blob')) { // default filename value for "Blobs" https://developer.mozilla.org/en-US/docs/Web/API/FormData/append
+        function parseData(decoder) {
+          fileStream.pipe(concat({ encoding: 'string' }, function (data) {
+            appendField(req.body, fieldname, typeof decoder === 'function' ? decoder(data) : data)
+          }))
+        }
+
+        switch (mimetype) {
+          case 'text/csv':
+            return parseData()
+          case 'application/json':
+            return parseData(function(data) {
+              try {
+                return JSON.parse(data)
+              } catch (err) {
+                console.warn('failed parsing json in ', fieldname, err)
+              }
+            })
+          default:
+            console.warn('ignored multipart with fieldname', fieldname, mimetype)
+            return fileStream.resume()
+        }
+      }
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && limits.hasOwnProperty('fieldNameSize')) {

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -98,7 +98,7 @@ function makeMiddleware (setup) {
     busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
       // don't attach to the files object, if there is no file
       if (!filename || (parseBlobs && filename === 'blob')) { // default filename value for "Blobs" https://developer.mozilla.org/en-US/docs/Web/API/FormData/append
-        function parseData(decoder) {
+        var parseData = function (decoder) {
           fileStream.pipe(concat({ encoding: 'string' }, function (data) {
             appendField(req.body, fieldname, typeof decoder === 'function' ? decoder(data) : data)
           }))
@@ -108,7 +108,7 @@ function makeMiddleware (setup) {
           case 'text/csv':
             return parseData()
           case 'application/json':
-            return parseData(function(data) {
+            return parseData(function (data) {
               try {
                 return JSON.parse(data)
               } catch (err) {


### PR DESCRIPTION
this change allows parsing files without "filenames".. which is the case if you insert a blob with a content-type json/application for example:

```
const form = new FormData();
form.append('jsonStuff', new Blob([JSON.stringify({a: 1})], {type: 'application/json'}, ''); // passing a 3rd empty paramter sets the filename to an empty string, if not, the default value is "blob". Setting parseBlobs to true, would also handle the filename "blob" in this case.
```

results into:
------WebKitFormBoundaryeFyAvRTAPR4MqtxM
Content-Disposition: form-data; name="jsonStuff"; filename=""
Content-Type: application/json

{a: 1}

Therefore multer will be able to handle non-files and it is possible to send files and json data within one request.

This topic has a history in busboy, see mscdex/busboy#200 and mscdex/busboy#201

But I agree, this should be handled within multer.

It's a non breaking change, as empty filenames have been ignored till today anyway, and the "blob" filename case is just a new option that needs to be set explicty.