### PR TITLE
chore: Update mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.13.1",
     "form-data": "^1.0.0-rc1",
     "fs-temp": "^1.1.2",
-    "mocha": "^3.5.3",
+    "mocha": "^4.1.0",
     "rimraf": "^2.4.1",
     "standard": "^11.0.1",
     "testdata-w3c-json-form": "^0.2.0"

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -13,11 +13,15 @@ var onFinished = require('on-finished')
 var port = 34279
 
 describe('Express Integration', function () {
-  var app
+  var app, server
 
   before(function (done) {
     app = express()
-    app.listen(port, done)
+    server = app.listen(port, done)
+  })
+
+  after(function () {
+    server.close()
   })
 
   function submitForm (form, path, cb) {


### PR DESCRIPTION
Update mocha from 3.5 to 4.1. This resolves some issues reported by `npm
audit`.

To work with mocha 6, the express test had to explicitly the server.
Mocha no longer forces an exit when it thinks the test is done, so the
server was keeping the process running, causing the test suite to never
finish.