### PR TITLE
chore: Update testdata-w3c-json-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "^3.5.3",
     "rimraf": "^2.4.1",
     "standard": "^11.0.1",
-    "testdata-w3c-json-form": "^0.2.0"
+    "testdata-w3c-json-form": "^1.0.0"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
Version 1.0.0 of testdata-w3c-json-form contains a correction to the
test data. Without the correction (of the bottle-on-wall type from an
array of numbers to an array of strings), it is possible that tests will
break in Node.js 13.0.0 or a future release.