### PR TITLE
chore: Update mocha from 3.x to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.13.1",
     "form-data": "^1.0.0-rc1",
     "fs-temp": "^1.1.2",
-    "mocha": "^3.5.3",
+    "mocha": "^4.1.0",
     "rimraf": "^2.4.1",
     "standard": "^11.0.1",
     "testdata-w3c-json-form": "^0.2.0"

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -13,11 +13,15 @@ var onFinished = require('on-finished')
 var port = 34279
 
 describe('Express Integration', function () {
-  var app
+  var app, server
 
   before(function (done) {
     app = express()
-    app.listen(port, done)
+    server = app.listen(port, done)
+  })
+
+  after(function (done) {
+    server.close(done)
   })
 
   function submitForm (form, path, cb) {


### PR DESCRIPTION
Update mocha from 3.x to 4.x. This removes a pair of warnings from `npm
audit`. The epxress test needed to explicitly close the server when done
as mocha 4.x does not do this by default the way 3.x did.