### PR TITLE
Call callback when file close occurs, not finish.

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -39,7 +39,7 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       file.stream.pipe(outStream)
       outStream.on('error', cb)
-      outStream.on('finish', function () {
+      outStream.on('close', function () {
         cb(null, {
           destination: destination,
           filename: filename,


### PR DESCRIPTION
The [finish](https://nodejs.org/api/stream.html#stream_event_finish) event is called after the stream has been streamed to the underlying system. This does not take into account closing the underlying file descriptor and can ultimately lead to unexpected problems when working with network file systems and other latency bound file systems. To get around this, we should instead use the [close](https://nodejs.org/api/stream.html#stream_event_close) event to account for all of the underlying systems being handled after the upload. 

We have experienced these issues in the following situation:
- Using AWS EFS (https://aws.amazon.com/efs/)
- Using vanilla NFS

The issue occurred when we had an expressjs server with multer middleware handling upload to the network filesystem, and then subsequently call an API to cause processing from another service also connected to the NFS. We have verified that this fixes the situation for both NFS and EFS.