### PR TITLE
use 'close' event on file stream for reliability

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -39,7 +39,7 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       file.stream.pipe(outStream)
       outStream.on('error', cb)
-      outStream.on('finish', function () {
+      outStream.on('close', function () {
         cb(null, {
           destination: destination,
           filename: filename,


### PR DESCRIPTION
Change listened-for event on the output stream in storage/disk.js from
'finish' to 'close' to improve reliability. With 'finish', there is a
race condition such that sometimes the callback runs before the file
exists.

Refs: https://github.com/expressjs/multer/issues/238