### PR TITLE
add execute request pipe. Fixes #572, #411

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ app.post('/profile', function (req, res) {
   })
 })
 ```
-## Custom request pipe busboy (Example firebase + multer + firebase storage)
+## Custom request pipe busboy (Example firebase + express + multer + firebase storage)
 ```javascript
 const admin = require("firebase-admin");
 const express = require("express");
@@ -304,7 +304,7 @@ app.use(bodyParser.urlencoded({ limit: "10mb", extended: true }));
 const multerMiddleware = multer({
   storage: multer.memoryStorage(),
   // Custom request pipe with busboy
-  executeRequestPipe: (req, busboy) => {
+  executeRequestPipeBusboy: (req, busboy) => {
     return busboy.end(req.rawBody);
   }
 });

--- a/README.md
+++ b/README.md
@@ -292,7 +292,15 @@ app.post('/profile', function (req, res) {
 ```
 ## Custom request pipe busboy (firebase + firebase storage)
 ```javascript
-var multer = require('multer')
+const admin = require("firebase-admin");
+const express = require("express");
+const multer = require('multer');
+const bodyParser = require("body-parser");
+const firebase = admin.initializeApp({
+  credential: admin.credential.cert(require("your_service_account.json")),
+});
+const app = express();
+app.use(bodyParser.urlencoded({ limit: "10mb", extended: true }));
 const multerMiddleware = multer({
   storage: multer.memoryStorage(),
   // Custom request pipe with busboy
@@ -327,7 +335,7 @@ app.post("/upload", multerMiddleware.single("file"), (req, res) => {
 
   blobStream.end(req.file.buffer);
 });
-
+exports.api = functions.https.onRequest(app);
 ```
 
 ## Custom storage engine

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ app.post('/profile', function (req, res) {
   })
 })
 ```
-## Custom request pipe busboy (firebase + firebase storage)
+## Custom request pipe busboy (Example firebase + multer + firebase storage)
 ```javascript
 const admin = require("firebase-admin");
 const express = require("express");

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
+  this.executeRequestPipe = (typeof options.executeRequestPipe === 'function' && options.executeRequestPipeBusboy) || null
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -52,7 +53,9 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       fileStrategy: fileStrategy
     }
   }
-
+  if (this.executeRequestPipe) {
+    return makeMiddleware(setup.bind(this), this.executeRequestPipeBusboy)
+  }
   return makeMiddleware(setup.bind(this))
 }
 

--- a/index.js
+++ b/index.js
@@ -53,10 +53,7 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       fileStrategy: fileStrategy
     }
   }
-  if (this.executeRequestPipe) {
-    return makeMiddleware(setup.bind(this), this.executeRequestPipeBusboy)
-  }
-  return makeMiddleware(setup.bind(this))
+  return makeMiddleware(setup.bind(this), this.executeRequestPipeBusboy)
 }
 
 Multer.prototype.single = function (name) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
-  this.executeRequestPipe = (typeof options.executeRequestPipe === 'function' && options.executeRequestPipeBusboy) || null
+  this.executeRequestPipeBusboy = (typeof options.executeRequestPipeBusboy === 'function' && options.executeRequestPipeBusboy) || null
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -13,9 +13,12 @@ function drainStream (stream) {
   stream.on('readable', stream.read.bind(stream))
 }
 
-function makeMiddleware (setup, executeRequestPipeBusboy = function (req, busboy) {
-  req.pipe(busboy)
-}) {
+function makeMiddleware (setup, executeRequestPipeBusboy) {
+  if (!executeRequestPipeBusboy) {
+    executeRequestPipeBusboy = function (req, busboy) {
+      req.pipe(busboy)
+    }
+  }
   return function multerMiddleware (req, res, next) {
     if (!is(req, ['multipart'])) return next()
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -13,7 +13,9 @@ function drainStream (stream) {
   stream.on('readable', stream.read.bind(stream))
 }
 
-function makeMiddleware (setup) {
+function makeMiddleware (setup, executeRequestPipeBusboy = function (req, busboy) {
+  req.pipe(busboy)
+}) {
   return function multerMiddleware (req, res, next) {
     if (!is(req, ['multipart'])) return next()
 
@@ -173,7 +175,7 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
-    req.pipe(busboy)
+    executeRequestPipeBusboy(req, busboy)
   }
 }
 


### PR DESCRIPTION
There was a breaking change in the Cloud Functions setup that triggered this issue. It has to do with the way the middleware works that gets applied to all Express apps (including the default app) used to serve HTTPS functions. Basically, Cloud Functions will parse the body of the request and decide what to do with it, leaving the raw contents of the body in a Buffer in req.rawBody. 

I added a parameter in the configuration to be able to manipulate the call to busboy. Fixes #572, #411