### PR TITLE
Add `startProcessing` config for pre-processed request objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ app.post('/profile', upload.none(), function (req, res, next) {
 })
 ```
 
+Custom `startProcessing` function to handle pre-processed request object, useful when dealing with cloud functions or environments that processes http `request` object before it can hit the express application.
+
+```javascript
+var express = require('express')
+var app = express()
+var multer  = require('multer')
+var upload = multer({
+  startProcessing (req, busboy) {
+    if (req.rawBody) { // indicates the request was pre-processed
+      busboy.end(req.rawBody)
+    } else {
+      req.pipe(busboy)
+    }
+  }
+})
+
+app.post('/profile', upload.none(), function (req, res, next) {
+  // req.body contains the text fields
+})
+```
+
 ## API
 
 ### File information
@@ -110,6 +131,7 @@ Key | Description
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
 `preservePath` | Keep the full path of files instead of just the base name
+`startProcessing` | Function that will be invoked to initiate the request processing with busboy
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function allowAll (req, file, cb) {
   cb(null, true)
 }
 
+function startProcessing (req, busboy) {
+  req.pipe(busboy)
+}
+
 function Multer (options) {
   if (options.storage) {
     this.storage = options.storage
@@ -20,6 +24,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
+  this.startProcessing = options.startProcessing || startProcessing
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,7 +54,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      startProcessing: this.startProcessing
     }
   }
 
@@ -79,7 +85,8 @@ Multer.prototype.any = function () {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: this.fileFilter,
-      fileStrategy: 'ARRAY'
+      fileStrategy: 'ARRAY',
+      startProcessing: this.startProcessing
     }
   }
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -24,6 +24,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var startProcessing = options.startProcessing
 
     req.body = Object.create(null)
 
@@ -173,7 +174,7 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
-    req.pipe(busboy)
+    startProcessing(req, busboy)
   }
 }
 

--- a/test/start-processing.js
+++ b/test/start-processing.js
@@ -1,0 +1,124 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var multer = require('../')
+var util = require('./_util')
+
+var express = require('express')
+var FormData = require('form-data')
+var concat = require('concat-stream')
+var onFinished = require('on-finished')
+
+var port = 34280
+var localhostUrl = function (path) { return 'http://localhost:' + port + path }
+
+describe('Start Processing', function () {
+  var app
+  var server
+
+  beforeEach(function (done) {
+    app = express()
+    server = app.listen(port, done)
+  })
+
+  afterEach(function (done) {
+    server.close(done)
+  })
+
+  function submitForm (form, path, cb) {
+    var req = form.submit(localhostUrl(path))
+
+    req.on('error', cb)
+    req.on('response', function (res) {
+      res.on('error', cb)
+      res.pipe(concat({ encoding: 'buffer' }, function (body) {
+        onFinished(req, function () { cb(null, res, body) })
+      }))
+    })
+  }
+
+  function testData (data, done) {
+    var upload = multer(data.cfg)
+    var form = new FormData()
+
+    var routeCalled = 0
+    var errorCalled = 0
+
+    data.fields && data.fields.forEach(function (field) {
+      form.append(field.key, field.value)
+    })
+    data.files && data.files.forEach(function (file) {
+      form.append(file.key, util.file(file.value))
+    })
+
+    app.post('/test_route', upload.any(), function (req, res, next) {
+      data.fields && data.fields.forEach(function (field) {
+        assert.equal(req.body[field.key], field.value)
+      })
+      data.files && data.files.forEach(function (file, index) {
+        assert.equal(req.files[index].fieldname, file.key)
+        assert.equal(req.files[0].originalname, file.value)
+      })
+
+      routeCalled++
+      res.status(200).end('SUCCESS')
+    })
+
+    app.use(function (err, req, res, next) {
+      assert.ifError(err)
+
+      errorCalled++
+      res.status(500).end('ERROR')
+    })
+
+    submitForm(form, '/test_route', function (err, res, body) {
+      assert.ifError(err)
+
+      assert.equal(routeCalled, 1)
+      assert.equal(errorCalled, 0)
+      assert.equal(body.toString(), 'SUCCESS')
+      assert.equal(res.statusCode, 200)
+
+      done()
+    })
+  }
+
+  it('should start processing by default', function (done) {
+    testData({
+      fields: [{key: 'testField', value: 'testValue1'}],
+      files: [{key: 'testFile', value: 'tiny1.dat'}]
+    }, done)
+  })
+
+  it('should invoke method to start processing', function (done) {
+    app.use(function (req, res, next) {
+      req.rawBody = ''
+      req.setEncoding('utf8')
+      req.on('data', function (chunk) { req.rawBody += chunk })
+      req.on('end', function () {
+        next()
+      })
+    })
+
+    var startProcessingCallCount = 0
+
+    testData({
+      fields: [{key: 'testField', value: 'testValue1'}],
+      files: [{key: 'testFile', value: 'tiny1.dat'}],
+      cfg: {
+        startProcessing: function (req, busboy) {
+          assert.ok(req)
+          assert.ok(busboy)
+          assert.ok(req.rawBody)
+
+          busboy.end(req.rawBody)
+          startProcessingCallCount++
+        }
+      }
+    }, function () {
+      assert.equal(startProcessingCallCount, 1)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
The following has been added to allow working with pre-processed request objects, eg those in cloud functions and similar environments.

-  ✨  `startProcessing` config
- 📚 Documentation update and sample usage
- 🚨 Tests to cover existing and updated use cases

Example:

```javascript
var express = require('express')
var app = express()
var multer  = require('multer')
var upload = multer({
  startProcessing (req, busboy) {
    if (req.rawBody) { // indicates the request was pre-processed
      busboy.end(req.rawBody)
    } else {
      req.pipe(busboy)
    }
  }
})

app.post('/profile', upload.none(), function (req, res, next) {
  // req.body contains the text fields
})
```