### PR TITLE
Clarify ambiguous error message; closes #799

### DIFF
--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -7,7 +7,7 @@ var errorMessages = {
   'LIMIT_FIELD_KEY': 'Field name too long',
   'LIMIT_FIELD_VALUE': 'Field value too long',
   'LIMIT_FIELD_COUNT': 'Too many fields',
-  'LIMIT_UNEXPECTED_FILE': 'Unexpected field'
+  'LIMIT_UNEXPECTED_FILE': 'Unexpected file in form-data'
 }
 
 function MulterError (code, field) {


### PR DESCRIPTION
Two ambiguities when not expecting an error: What and where. Both addressed.