### PR TITLE
Use make-dir instead of mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "append-field": "^1.0.0",
     "busboy": "^0.2.11",
     "concat-stream": "^1.5.2",
-    "mkdirp": "^0.5.1",
+    "make-dir": "^3.0.0",
     "object-assign": "^4.1.1",
     "on-finished": "^2.3.0",
     "type-is": "^1.6.4",

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var os = require('os')
 var path = require('path')
 var crypto = require('crypto')
-var mkdirp = require('mkdirp')
+var makeDir = require('make-dir')
 
 function getFilename (req, file, cb) {
   crypto.pseudoRandomBytes(16, function (err, raw) {
@@ -18,7 +18,7 @@ function DiskStorage (opts) {
   this.getFilename = (opts.filename || getFilename)
 
   if (typeof opts.destination === 'string') {
-    mkdirp.sync(opts.destination)
+    makeDir.sync(opts.destination)
     this.getDestination = function ($0, $1, cb) { cb(null, opts.destination) }
   } else {
     this.getDestination = (opts.destination || getDestination)

--- a/test/disk-storage.js
+++ b/test/disk-storage.js
@@ -169,6 +169,8 @@ describe('Disk Storage', function () {
   it('should create a directory when destination is a string', function (done) {
     var dest = path.join(temp.mkdirSync(), 'newDir')
 
+    assert.equal(fs.existsSync(dest), false)
+
     /* eslint-disable-next-line */
     var storage = multer.diskStorage({ destination: dest })
     assert.ok(fs.existsSync(dest), 'Destination was not created')

--- a/test/disk-storage.js
+++ b/test/disk-storage.js
@@ -166,6 +166,16 @@ describe('Disk Storage', function () {
     })
   })
 
+  it('should create a directory when destination is a string', function (done) {
+    var dest = path.join(temp.mkdirSync(), 'newDir')
+
+    /* eslint-disable-next-line */
+    var storage = multer.diskStorage({ destination: dest })
+    assert.ok(fs.existsSync(dest), 'Destination was not created')
+
+    done()
+  })
+
   it('should report error when directory doesn\'t exist', function (done) {
     var directory = path.join(temp.mkdirSync(), 'ghost')
     function dest ($0, $1, cb) { cb(null, directory) }


### PR DESCRIPTION
This PR is meant to fix #139

This PR replaces [`mkdirp`](https://www.npmjs.com/package/mkdirp) which doesn't seem to be maintained anymore with [`make-dir`](https://www.npmjs.com/package/make-dir).

I realize that v2 of multer likely [won't use storage engines at all](https://github.com/expressjs/multer/pull/399), but maybe this can make it into v1.x.

All tests pass, and I don't believe this should be breaking for anyone, as it should function exactly the same as `mkdirp` did previously. `make-dir` was created to replace `mkdirp`.

I also added a test to make sure that a path is created when `diskStorage` is given a string for `destination`, as per the docs.