### PR TITLE
Add Math.random() to storage filename example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ var storage = multer.diskStorage({
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    cb(null, file.fieldname + '-' + Date.now() + '-' + Math.random())
+    const uniqueHash = Date.now() + '-' + Math.random().split('.')[1]
+    cb(null, file.fieldname + '-' + uniqueHash)
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ var storage = multer.diskStorage({
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    cb(null, file.fieldname + '-' + Date.now())
+    cb(null, file.fieldname + '-' + Date.now() + '-' + Math.random())
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ var storage = multer.diskStorage({
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueHash = Date.now() + '-' + Math.random().split('.')[1]
-    cb(null, file.fieldname + '-' + uniqueHash)
+    const uniqueSuffix = Date.now() + '_' + (Math.random().toString().split('.')[1])
+    cb(null, file.fieldname + '_' + uniqueHash)
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ var storage = multer.diskStorage({
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '_' + (Math.random().toString().split('.')[1])
-    cb(null, file.fieldname + '_' + uniqueSuffix)
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
+    cb(null, file.fieldname + '-' + uniqueSuffix)
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ var storage = multer.diskStorage({
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '_' + (Math.random().toString().split('.')[1])
-    cb(null, file.fieldname + '_' + uniqueHash)
+    cb(null, file.fieldname + '_' + uniqueSuffix)
   }
 })
 


### PR DESCRIPTION
I was encountering an issue where two files had the same name due to being handled in the same millisecond. While not a bug, adding extra uniqueness may save someone else time troubleshooting 'missing' files.