### PR TITLE
add stricter default limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Key | Description | Default
 --- | --- | ---
 `fieldNameSize` | Max field name size | 100 bytes
 `fieldSize` | Max field value size | 1MB
-`fields` | Max number of non-file fields | Infinity
-`fileSize` | For multipart forms, the max file size (in bytes) | Infinity
+`fields` | Max number of non-file fields | 100 
+`fileSize` | For multipart forms, the max file size (in bytes) | 200MB
 `files` | For multipart forms, the max number of file fields | Infinity
 `parts` | For multipart forms, the max number of parts (fields + files) | Infinity
 `headerPairs` | For multipart forms, the max number of header key=>value pairs to parse | 2000

--- a/index.js
+++ b/index.js
@@ -12,7 +12,11 @@ function _middleware (limits, fields, fileStrategy) {
 
 class Multer {
   constructor (options) {
-    this.limits = options.limits
+    this.limits = {
+      fileSize: 200 * 1024 * 1024,
+      fields: 100,
+      ...options.limits
+    }
   }
 
   single (name) {

--- a/test/limits.js
+++ b/test/limits.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+const assert = require('assert')
 const assertRejects = require('assert-rejects')
 const FormData = require('form-data')
 
@@ -17,5 +18,13 @@ describe('limits', () => {
       util.submitForm(parser, form),
       (err) => err.code === 'LIMIT_FILE_SIZE' && err.field === 'file'
     )
+  })
+
+  it('should apply default limits', () => {
+    const parser = multer()
+    assert.deepStrictEqual(parser.limits, {
+      fileSize: 209715200,
+      fields: 100
+    })
   })
 })


### PR DESCRIPTION
Issue https://github.com/expressjs/multer/issues/182#issuecomment-592418154

Adds stricter default limits for `fields` and `fileSize`:

Other library limits as reference:
`fields`: multiparty: 100, node-formidable: 1000
`fileSize`: multiparty: Infinity, node-formidable: 200mb

https://github.com/node-formidable/node-formidable/blob/master/src/Formidable.js#L14-L22
https://github.com/pillarjs/multiparty/blob/master/index.js#L61-L63