### PR TITLE
bump mkdirp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "append-field": "^1.0.0",
     "busboy": "^0.2.11",
     "concat-stream": "^1.5.2",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.4",
     "object-assign": "^4.1.1",
     "on-finished": "^2.3.0",
     "type-is": "^1.6.4",


### PR DESCRIPTION
A new version of [mkdirp's 0.x](https://github.com/isaacs/node-mkdirp/pull/15) line has fixed the https://github.com/expressjs/multer/issues/139 infinite loop on windows issue

I do not know what the deal is with the one failing test on CI