### PR TITLE
Support Field Filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,11 @@ var diskStorage = require('./storage/disk')
 var memoryStorage = require('./storage/memory')
 var MulterError = require('./lib/multer-error')
 
-function allowAll (req, file, cb) {
+function allowAllFiles (req, file, cb) {
+  cb(null, true)
+}
+
+function allowAllFields (req, fieldname, value, cb) {
   cb(null, true)
 }
 
@@ -19,7 +23,8 @@ function Multer (options) {
 
   this.limits = options.limits
   this.preservePath = options.preservePath
-  this.fileFilter = options.fileFilter || allowAll
+  this.fileFilter = options.fileFilter || allowAllFiles
+  this.fieldFilter = options.fieldFilter || allowAllFields
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,7 +54,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      fieldFilter: this.fieldFilter
     }
   }
 
@@ -79,6 +85,7 @@ Multer.prototype.any = function () {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: this.fileFilter,
+      fieldFilter: this.fieldFilter,
       fileStrategy: 'ARRAY'
     }
   }

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -22,6 +22,7 @@ function makeMiddleware (setup) {
     var limits = options.limits
     var storage = options.storage
     var fileFilter = options.fileFilter
+    var fieldFilter = options.fieldFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
 
@@ -89,7 +90,15 @@ function makeMiddleware (setup) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 
-      appendField(req.body, fieldname, value)
+      fieldFilter(req, fieldname, value, function (err, includeField) {
+        if (err) {
+          return abortWithError(err)
+        }
+
+        if (includeField) {
+          appendField(req.body, fieldname, value)
+        }
+      })
     })
 
     // handle files

--- a/test/field-filter.js
+++ b/test/field-filter.js
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+
+function withFilter (fieldFilter) {
+  return multer({ fieldFilter: fieldFilter })
+}
+
+function skipSpecificField (req, fieldname, value, cb) {
+  cb(null, fieldname !== 'notme' && value !== 'notme')
+}
+
+function reportFakeError (req, fieldname, value, cb) {
+  cb(new Error('Fake error'))
+}
+
+describe('Field Filter', function () {
+  it('should skip some fields', function (done) {
+    var form = new FormData()
+    var upload = withFilter(skipSpecificField)
+    var parser = upload.any()
+
+    form.append('notme', 'notme')
+    form.append('butme', 'butme')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.equal(req.body['notme'], undefined)
+      assert.equal(req.body['butme'], 'butme')
+      done()
+    })
+  })
+
+  it('should report errors from fieldFilter', function (done) {
+    var form = new FormData()
+    var upload = withFilter(reportFakeError)
+    var parser = upload.single('test')
+
+    form.append('test', util.file('tiny0.dat'))
+    form.append('field', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.equal(err.message, 'Fake error')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
- Equivalent to file filter, except for fields

Because multer parses FormData based on the order of inputted values, sometimes file is parsed before fields. Ideally, if we can filter fields and reject before file upload that would be best.
```
const formData = new FormData();
formData.append('file', file, file.name);
formData.append('field', 'value');
```

Even so, we want to filter/validate fields and abort if necessary.
