### PR TITLE
package: bump standard

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -85,7 +85,7 @@ function makeMiddleware (setup) {
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
-      if (limits && limits.hasOwnProperty('fieldNameSize')) {
+      if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 
@@ -98,7 +98,7 @@ function makeMiddleware (setup) {
       if (!filename) return fileStream.resume()
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
-      if (limits && limits.hasOwnProperty('fieldNameSize')) {
+      if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -1,13 +1,13 @@
 var util = require('util')
 
 var errorMessages = {
-  'LIMIT_PART_COUNT': 'Too many parts',
-  'LIMIT_FILE_SIZE': 'File too large',
-  'LIMIT_FILE_COUNT': 'Too many files',
-  'LIMIT_FIELD_KEY': 'Field name too long',
-  'LIMIT_FIELD_VALUE': 'Field value too long',
-  'LIMIT_FIELD_COUNT': 'Too many fields',
-  'LIMIT_UNEXPECTED_FILE': 'Unexpected field'
+  LIMIT_PART_COUNT: 'Too many parts',
+  LIMIT_FILE_SIZE: 'File too large',
+  LIMIT_FILE_COUNT: 'Too many files',
+  LIMIT_FIELD_KEY: 'Field name too long',
+  LIMIT_FIELD_VALUE: 'Field value too long',
+  LIMIT_FIELD_COUNT: 'Too many fields',
+  LIMIT_UNEXPECTED_FILE: 'Unexpected field'
 }
 
 function MulterError (code, field) {

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "deep-equal": "^2.0.3",
     "express": "^4.13.1",
     "form-data": "^1.0.0-rc1",
     "fs-temp": "^1.1.2",
     "mocha": "^3.5.3",
     "rimraf": "^2.4.1",
-    "standard": "^11.0.1",
+    "standard": "^14.3.3",
     "testdata-w3c-json-form": "^1.0.0"
   },
   "engines": {

--- a/test/disk-storage.js
+++ b/test/disk-storage.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert')
+var deepEqual = require('deep-equal')
 
 var fs = require('fs')
 var path = require('path')
@@ -37,12 +38,12 @@ describe('Disk Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(req.body.name, 'Multer')
+      assert.strictEqual(req.body.name, 'Multer')
 
-      assert.equal(req.file.fieldname, 'small0')
-      assert.equal(req.file.originalname, 'small0.dat')
-      assert.equal(req.file.size, 1778)
-      assert.equal(util.fileSize(req.file.path), 1778)
+      assert.strictEqual(req.file.fieldname, 'small0')
+      assert.strictEqual(req.file.originalname, 'small0.dat')
+      assert.strictEqual(req.file.size, 1778)
+      assert.strictEqual(util.fileSize(req.file.path), 1778)
 
       done()
     })
@@ -66,18 +67,18 @@ describe('Disk Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(req.body.name, 'Multer')
-      assert.equal(req.body.version, '')
-      assert.equal(req.body.year, '')
+      assert.strictEqual(req.body.name, 'Multer')
+      assert.strictEqual(req.body.version, '')
+      assert.strictEqual(req.body.year, '')
 
-      assert.deepEqual(req.body.checkboxfull, [ 'cb1', 'cb2' ])
-      assert.deepEqual(req.body.checkboxhalfempty, [ 'cb1', '' ])
-      assert.deepEqual(req.body.checkboxempty, [ '', '' ])
+      assert(deepEqual(req.body.checkboxfull, ['cb1', 'cb2']))
+      assert(deepEqual(req.body.checkboxhalfempty, ['cb1', '']))
+      assert(deepEqual(req.body.checkboxempty, ['', '']))
 
-      assert.equal(req.file.fieldname, 'empty')
-      assert.equal(req.file.originalname, 'empty.dat')
-      assert.equal(req.file.size, 0)
-      assert.equal(util.fileSize(req.file.path), 0)
+      assert.strictEqual(req.file.fieldname, 'empty')
+      assert.strictEqual(req.file.originalname, 'empty.dat')
+      assert.strictEqual(req.file.size, 0)
+      assert.strictEqual(util.fileSize(req.file.path), 0)
 
       done()
     })
@@ -106,42 +107,42 @@ describe('Disk Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.deepEqual(req.body, {})
+      assert(deepEqual(req.body, {}))
 
-      assert.equal(req.files['empty'][0].fieldname, 'empty')
-      assert.equal(req.files['empty'][0].originalname, 'empty.dat')
-      assert.equal(req.files['empty'][0].size, 0)
-      assert.equal(util.fileSize(req.files['empty'][0].path), 0)
+      assert.strictEqual(req.files.empty[0].fieldname, 'empty')
+      assert.strictEqual(req.files.empty[0].originalname, 'empty.dat')
+      assert.strictEqual(req.files.empty[0].size, 0)
+      assert.strictEqual(util.fileSize(req.files.empty[0].path), 0)
 
-      assert.equal(req.files['tiny0'][0].fieldname, 'tiny0')
-      assert.equal(req.files['tiny0'][0].originalname, 'tiny0.dat')
-      assert.equal(req.files['tiny0'][0].size, 122)
-      assert.equal(util.fileSize(req.files['tiny0'][0].path), 122)
+      assert.strictEqual(req.files.tiny0[0].fieldname, 'tiny0')
+      assert.strictEqual(req.files.tiny0[0].originalname, 'tiny0.dat')
+      assert.strictEqual(req.files.tiny0[0].size, 122)
+      assert.strictEqual(util.fileSize(req.files.tiny0[0].path), 122)
 
-      assert.equal(req.files['tiny1'][0].fieldname, 'tiny1')
-      assert.equal(req.files['tiny1'][0].originalname, 'tiny1.dat')
-      assert.equal(req.files['tiny1'][0].size, 7)
-      assert.equal(util.fileSize(req.files['tiny1'][0].path), 7)
+      assert.strictEqual(req.files.tiny1[0].fieldname, 'tiny1')
+      assert.strictEqual(req.files.tiny1[0].originalname, 'tiny1.dat')
+      assert.strictEqual(req.files.tiny1[0].size, 7)
+      assert.strictEqual(util.fileSize(req.files.tiny1[0].path), 7)
 
-      assert.equal(req.files['small0'][0].fieldname, 'small0')
-      assert.equal(req.files['small0'][0].originalname, 'small0.dat')
-      assert.equal(req.files['small0'][0].size, 1778)
-      assert.equal(util.fileSize(req.files['small0'][0].path), 1778)
+      assert.strictEqual(req.files.small0[0].fieldname, 'small0')
+      assert.strictEqual(req.files.small0[0].originalname, 'small0.dat')
+      assert.strictEqual(req.files.small0[0].size, 1778)
+      assert.strictEqual(util.fileSize(req.files.small0[0].path), 1778)
 
-      assert.equal(req.files['small1'][0].fieldname, 'small1')
-      assert.equal(req.files['small1'][0].originalname, 'small1.dat')
-      assert.equal(req.files['small1'][0].size, 315)
-      assert.equal(util.fileSize(req.files['small1'][0].path), 315)
+      assert.strictEqual(req.files.small1[0].fieldname, 'small1')
+      assert.strictEqual(req.files.small1[0].originalname, 'small1.dat')
+      assert.strictEqual(req.files.small1[0].size, 315)
+      assert.strictEqual(util.fileSize(req.files.small1[0].path), 315)
 
-      assert.equal(req.files['medium'][0].fieldname, 'medium')
-      assert.equal(req.files['medium'][0].originalname, 'medium.dat')
-      assert.equal(req.files['medium'][0].size, 13196)
-      assert.equal(util.fileSize(req.files['medium'][0].path), 13196)
+      assert.strictEqual(req.files.medium[0].fieldname, 'medium')
+      assert.strictEqual(req.files.medium[0].originalname, 'medium.dat')
+      assert.strictEqual(req.files.medium[0].size, 13196)
+      assert.strictEqual(util.fileSize(req.files.medium[0].path), 13196)
 
-      assert.equal(req.files['large'][0].fieldname, 'large')
-      assert.equal(req.files['large'][0].originalname, 'large.jpg')
-      assert.equal(req.files['large'][0].size, 2413677)
-      assert.equal(util.fileSize(req.files['large'][0].path), 2413677)
+      assert.strictEqual(req.files.large[0].fieldname, 'large')
+      assert.strictEqual(req.files.large[0].originalname, 'large.jpg')
+      assert.strictEqual(req.files.large[0].size, 2413677)
+      assert.strictEqual(util.fileSize(req.files.large[0].path), 2413677)
 
       done()
     })
@@ -155,12 +156,12 @@ describe('Disk Storage', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'small0')
-      assert.deepEqual(err.storageErrors, [])
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'small0')
+      assert(deepEqual(err.storageErrors, []))
 
       var files = fs.readdirSync(uploadDir)
-      assert.deepEqual(files, [])
+      assert(deepEqual(files, []))
 
       done()
     })
@@ -178,8 +179,8 @@ describe('Disk Storage', function () {
     form.append('tiny0', util.file('tiny0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'ENOENT')
-      assert.equal(path.dirname(err.path), directory)
+      assert.strictEqual(err.code, 'ENOENT')
+      assert.strictEqual(path.dirname(err.path), directory)
 
       done()
     })

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -17,7 +17,7 @@ describe('Error Handling', function () {
   it('should be an instance of both `Error` and `MulterError` classes in case of the Multer\'s error', function (done) {
     var form = new FormData()
     var storage = multer.diskStorage({ destination: os.tmpdir() })
-    var upload = multer({storage: storage}).fields([
+    var upload = multer({ storage: storage }).fields([
       { name: 'small0', maxCount: 1 }
     ])
 
@@ -25,8 +25,8 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(upload, form, function (err, req) {
-      assert.equal(err instanceof Error, true)
-      assert.equal(err instanceof multer.MulterError, true)
+      assert.strictEqual(err instanceof Error, true)
+      assert.strictEqual(err instanceof multer.MulterError, true)
       done()
     })
   })
@@ -41,7 +41,7 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_PART_COUNT')
+      assert.strictEqual(err.code, 'LIMIT_PART_COUNT')
       done()
     })
   })
@@ -57,8 +57,8 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FILE_SIZE')
-      assert.equal(err.field, 'small0')
+      assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
+      assert.strictEqual(err.field, 'small0')
       done()
     })
   })
@@ -74,7 +74,7 @@ describe('Error Handling', function () {
     form.append('small1', util.file('small1.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FILE_COUNT')
+      assert.strictEqual(err.code, 'LIMIT_FILE_COUNT')
       done()
     })
   })
@@ -88,7 +88,7 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FIELD_KEY')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_KEY')
       done()
     })
   })
@@ -101,7 +101,7 @@ describe('Error Handling', function () {
     form.append('blowup', 'BOOM!')
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FIELD_KEY')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_KEY')
       done()
     })
   })
@@ -114,8 +114,8 @@ describe('Error Handling', function () {
     form.append('field1', 'This will make the parser explode')
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FIELD_VALUE')
-      assert.equal(err.field, 'field1')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_VALUE')
+      assert.strictEqual(err.field, 'field1')
       done()
     })
   })
@@ -128,7 +128,7 @@ describe('Error Handling', function () {
     form.append('field1', 'BOOM!')
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FIELD_COUNT')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_COUNT')
       done()
     })
   })
@@ -142,8 +142,8 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'small0')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'small0')
       done()
     })
   })
@@ -165,13 +165,13 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'small0')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'small0')
 
-      assert.equal(err.storageErrors.length, 1)
-      assert.equal(err.storageErrors[0].code, 'TEST')
-      assert.equal(err.storageErrors[0].field, 'tiny0')
-      assert.equal(err.storageErrors[0].file, req.file)
+      assert.strictEqual(err.storageErrors.length, 1)
+      assert.strictEqual(err.storageErrors[0].code, 'TEST')
+      assert.strictEqual(err.storageErrors[0].field, 'tiny0')
+      assert.strictEqual(err.storageErrors[0].file, req.file)
 
       done()
     })
@@ -191,7 +191,7 @@ describe('Error Handling', function () {
     req.end(body)
 
     upload(req, null, function (err) {
-      assert.equal(err.message, 'Multipart: Boundary not found')
+      assert.strictEqual(err.message, 'Multipart: Boundary not found')
       done()
     })
   })
@@ -217,7 +217,7 @@ describe('Error Handling', function () {
     req.end(body)
 
     upload(req, null, function (err) {
-      assert.equal(err.message, 'Unexpected end of multipart data')
+      assert.strictEqual(err.message, 'Unexpected end of multipart data')
       done()
     })
   })
@@ -233,7 +233,7 @@ describe('Error Handling', function () {
     form.append('small0', util.file('small0.dat'))
 
     util.submitForm(upload, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_FILE_SIZE')
+      assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
       done()
     })
   })

--- a/test/expected-files.js
+++ b/test/expected-files.js
@@ -21,8 +21,8 @@ describe('Expected files', function () {
     form.append('notme', util.file('small0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'notme')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'notme')
       done()
     })
   })
@@ -35,8 +35,8 @@ describe('Expected files', function () {
     form.append('notme', util.file('small1.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'notme')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'notme')
       done()
     })
   })
@@ -49,8 +49,8 @@ describe('Expected files', function () {
     form.append('butme', util.file('small1.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'butme')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'butme')
       done()
     })
   })
@@ -69,8 +69,8 @@ describe('Expected files', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(req.files['butme'].length, 2)
-      assert.equal(req.files['andme'].length, 1)
+      assert.strictEqual(req.files.butme.length, 2)
+      assert.strictEqual(req.files.andme.length, 1)
 
       done()
     })
@@ -89,8 +89,8 @@ describe('Expected files', function () {
     form.append('notme', util.file('empty.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(err.field, 'notme')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(err.field, 'notme')
       done()
     })
   })
@@ -105,10 +105,10 @@ describe('Expected files', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.equal(req.files.length, 3)
-      assert.equal(req.files[0].fieldname, 'butme')
-      assert.equal(req.files[1].fieldname, 'butme')
-      assert.equal(req.files[2].fieldname, 'andme')
+      assert.strictEqual(req.files.length, 3)
+      assert.strictEqual(req.files[0].fieldname, 'butme')
+      assert.strictEqual(req.files[1].fieldname, 'butme')
+      assert.strictEqual(req.files[2].fieldname, 'andme')
       done()
     })
   })

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -49,7 +49,7 @@ describe('Express Integration', function () {
     })
 
     router.use(function (err, req, res, next) {
-      assert.equal(err.code, 'LIMIT_FILE_SIZE')
+      assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
 
       errorCalled++
       res.status(500).end('ERROR')
@@ -59,10 +59,10 @@ describe('Express Integration', function () {
     submitForm(form, '/t1/profile', function (err, res, body) {
       assert.ifError(err)
 
-      assert.equal(routeCalled, 0)
-      assert.equal(errorCalled, 1)
-      assert.equal(body.toString(), 'ERROR')
-      assert.equal(res.statusCode, 500)
+      assert.strictEqual(routeCalled, 0)
+      assert.strictEqual(errorCalled, 1)
+      assert.strictEqual(body.toString(), 'ERROR')
+      assert.strictEqual(res.statusCode, 500)
 
       done()
     })
@@ -88,7 +88,7 @@ describe('Express Integration', function () {
     })
 
     router.use(function (err, req, res, next) {
-      assert.equal(err.message, 'TEST')
+      assert.strictEqual(err.message, 'TEST')
 
       errorCalled++
       res.status(500).end('ERROR')
@@ -98,10 +98,10 @@ describe('Express Integration', function () {
     submitForm(form, '/t2/profile', function (err, res, body) {
       assert.ifError(err)
 
-      assert.equal(routeCalled, 0)
-      assert.equal(errorCalled, 1)
-      assert.equal(body.toString(), 'ERROR')
-      assert.equal(res.statusCode, 500)
+      assert.strictEqual(routeCalled, 0)
+      assert.strictEqual(errorCalled, 1)
+      assert.strictEqual(body.toString(), 'ERROR')
+      assert.strictEqual(res.statusCode, 500)
 
       done()
     })

--- a/test/fields.js
+++ b/test/fields.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert')
+var deepEqual = require('deep-equal')
 var stream = require('stream')
 
 var util = require('./_util')
@@ -24,11 +25,11 @@ describe('Fields', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.deepEqual(req.body, {
+      assert(deepEqual(req.body, {
         name: 'Multer',
         key: 'value',
         abc: 'xyz'
-      })
+      }))
       done()
     })
   })
@@ -48,14 +49,14 @@ describe('Fields', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.deepEqual(req.body, {
+      assert(deepEqual(req.body, {
         name: 'Multer',
         key: '',
         abc: '',
-        checkboxfull: [ 'cb1', 'cb2' ],
-        checkboxhalfempty: [ 'cb1', '' ],
-        checkboxempty: [ '', '' ]
-      })
+        checkboxfull: ['cb1', 'cb2'],
+        checkboxhalfempty: ['cb1', ''],
+        checkboxempty: ['', '']
+      }))
       done()
     })
   })
@@ -72,8 +73,8 @@ describe('Fields', function () {
 
     parser(req, null, function (err) {
       assert.ifError(err)
-      assert.equal(req.hasOwnProperty('body'), false)
-      assert.equal(req.hasOwnProperty('files'), false)
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(req, 'body'), false)
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(req, 'files'), false)
       done()
     })
   })
@@ -90,8 +91,8 @@ describe('Fields', function () {
 
     parser(req, null, function (err) {
       assert.ifError(err)
-      assert.equal(req.hasOwnProperty('body'), false)
-      assert.equal(req.hasOwnProperty('files'), false)
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(req, 'body'), false)
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(req, 'files'), false)
       done()
     })
   })
@@ -106,7 +107,7 @@ describe('Fields', function () {
 
       util.submitForm(parser, form, function (err, req) {
         assert.ifError(err)
-        assert.deepEqual(req.body, test.expected)
+        assert(deepEqual(req.body, test.expected))
         done()
       })
     })
@@ -121,13 +122,13 @@ describe('Fields', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.deepEqual(req.body, {
+      assert(deepEqual(req.body, {
         obj: {
-          '0': 'a',
-          '2': 'c',
-          'x': 'yz'
+          0: 'a',
+          2: 'c',
+          x: 'yz'
         }
-      })
+      }))
       done()
     })
   })

--- a/test/file-filter.js
+++ b/test/file-filter.js
@@ -32,11 +32,11 @@ describe('File Filter', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.equal(req.files['notme'], undefined)
-      assert.equal(req.files['butme'][0].fieldname, 'butme')
-      assert.equal(req.files['butme'][0].originalname, 'tiny1.dat')
-      assert.equal(req.files['butme'][0].size, 7)
-      assert.equal(req.files['butme'][0].buffer.length, 7)
+      assert.strictEqual(req.files.notme, undefined)
+      assert.strictEqual(req.files.butme[0].fieldname, 'butme')
+      assert.strictEqual(req.files.butme[0].originalname, 'tiny1.dat')
+      assert.strictEqual(req.files.butme[0].size, 7)
+      assert.strictEqual(req.files.butme[0].buffer.length, 7)
       done()
     })
   })
@@ -49,7 +49,7 @@ describe('File Filter', function () {
     form.append('test', util.file('tiny0.dat'))
 
     util.submitForm(parser, form, function (err, req) {
-      assert.equal(err.message, 'Fake error')
+      assert.strictEqual(err.message, 'Fake error')
       done()
     })
   })

--- a/test/file-ordering.js
+++ b/test/file-ordering.js
@@ -39,9 +39,9 @@ describe('File ordering', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.equal(req.files.length, 2)
-      assert.equal(req.files[0].originalname, 'small0.dat')
-      assert.equal(req.files[1].originalname, 'small1.dat')
+      assert.strictEqual(req.files.length, 2)
+      assert.strictEqual(req.files[0].originalname, 'small0.dat')
+      assert.strictEqual(req.files[1].originalname, 'small1.dat')
       done()
     })
   })

--- a/test/functionality.js
+++ b/test/functionality.js
@@ -52,7 +52,7 @@ describe('Functionality', function () {
       util.submitForm(parser, env.form, function (err, req) {
         assert.ifError(err)
         assert.ok(startsWith(req.file.path, env.uploadDir))
-        assert.equal(util.fileSize(req.file.path), 1778)
+        assert.strictEqual(util.fileSize(req.file.path), 1778)
         done()
       })
     })
@@ -67,7 +67,7 @@ describe('Functionality', function () {
 
       util.submitForm(parser, env.form, function (err, req) {
         assert.ifError(err)
-        assert.equal(req.file.filename, 'small0small0.dat')
+        assert.strictEqual(req.file.filename, 'small0small0.dat')
         done()
       })
     })
@@ -82,7 +82,7 @@ describe('Functionality', function () {
 
       util.submitForm(parser, env.form, function (err, req) {
         assert.ifError(err)
-        assert.equal(req.file.filename, 'tiny0tiny0.dat')
+        assert.strictEqual(req.file.filename, 'tiny0tiny0.dat')
         done()
       })
     })
@@ -98,9 +98,9 @@ describe('Functionality', function () {
 
       util.submitForm(parser, env.form, function (err, req) {
         assert.ifError(err)
-        assert.equal(req.files.length, 2)
-        assert.equal(req.files[0].filename, 'themFilessmall0.dat')
-        assert.equal(req.files[1].filename, 'themFilessmall1.dat')
+        assert.strictEqual(req.files.length, 2)
+        assert.strictEqual(req.files[0].filename, 'themFilessmall0.dat')
+        assert.strictEqual(req.files[1].filename, 'themFilessmall1.dat')
         done()
       })
     })
@@ -128,7 +128,7 @@ describe('Functionality', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.equal(req.files.length, 2)
+      assert.strictEqual(req.files.length, 2)
       assert.ok(req.files[0].path.indexOf('/testforme-') >= 0)
       assert.ok(req.files[1].path.indexOf('/testforme-') >= 0)
       done()

--- a/test/issue-232.js
+++ b/test/issue-232.js
@@ -34,8 +34,8 @@ describe('Issue #232', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ok(err, 'an error was given')
 
-      assert.equal(err.code, 'LIMIT_FILE_SIZE')
-      assert.equal(err.field, 'file')
+      assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
+      assert.strictEqual(err.field, 'file')
 
       done()
     })

--- a/test/memory-storage.js
+++ b/test/memory-storage.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert')
+var deepEqual = require('deep-equal')
 
 var util = require('./_util')
 var multer = require('../')
@@ -24,12 +25,12 @@ describe('Memory Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(req.body.name, 'Multer')
+      assert.strictEqual(req.body.name, 'Multer')
 
-      assert.equal(req.file.fieldname, 'small0')
-      assert.equal(req.file.originalname, 'small0.dat')
-      assert.equal(req.file.size, 1778)
-      assert.equal(req.file.buffer.length, 1778)
+      assert.strictEqual(req.file.fieldname, 'small0')
+      assert.strictEqual(req.file.originalname, 'small0.dat')
+      assert.strictEqual(req.file.size, 1778)
+      assert.strictEqual(req.file.buffer.length, 1778)
 
       done()
     })
@@ -53,19 +54,19 @@ describe('Memory Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(req.body.name, 'Multer')
-      assert.equal(req.body.version, '')
-      assert.equal(req.body.year, '')
+      assert.strictEqual(req.body.name, 'Multer')
+      assert.strictEqual(req.body.version, '')
+      assert.strictEqual(req.body.year, '')
 
-      assert.deepEqual(req.body.checkboxfull, [ 'cb1', 'cb2' ])
-      assert.deepEqual(req.body.checkboxhalfempty, [ 'cb1', '' ])
-      assert.deepEqual(req.body.checkboxempty, [ '', '' ])
+      assert(deepEqual(req.body.checkboxfull, ['cb1', 'cb2']))
+      assert(deepEqual(req.body.checkboxhalfempty, ['cb1', '']))
+      assert(deepEqual(req.body.checkboxempty, ['', '']))
 
-      assert.equal(req.file.fieldname, 'empty')
-      assert.equal(req.file.originalname, 'empty.dat')
-      assert.equal(req.file.size, 0)
-      assert.equal(req.file.buffer.length, 0)
-      assert.equal(Buffer.isBuffer(req.file.buffer), true)
+      assert.strictEqual(req.file.fieldname, 'empty')
+      assert.strictEqual(req.file.originalname, 'empty.dat')
+      assert.strictEqual(req.file.size, 0)
+      assert.strictEqual(req.file.buffer.length, 0)
+      assert.strictEqual(Buffer.isBuffer(req.file.buffer), true)
 
       done()
     })
@@ -94,42 +95,42 @@ describe('Memory Storage', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.deepEqual(req.body, {})
+      assert(deepEqual(req.body, {}))
 
-      assert.equal(req.files['empty'][0].fieldname, 'empty')
-      assert.equal(req.files['empty'][0].originalname, 'empty.dat')
-      assert.equal(req.files['empty'][0].size, 0)
-      assert.equal(req.files['empty'][0].buffer.length, 0)
+      assert.strictEqual(req.files.empty[0].fieldname, 'empty')
+      assert.strictEqual(req.files.empty[0].originalname, 'empty.dat')
+      assert.strictEqual(req.files.empty[0].size, 0)
+      assert.strictEqual(req.files.empty[0].buffer.length, 0)
 
-      assert.equal(req.files['tiny0'][0].fieldname, 'tiny0')
-      assert.equal(req.files['tiny0'][0].originalname, 'tiny0.dat')
-      assert.equal(req.files['tiny0'][0].size, 122)
-      assert.equal(req.files['tiny0'][0].buffer.length, 122)
+      assert.strictEqual(req.files.tiny0[0].fieldname, 'tiny0')
+      assert.strictEqual(req.files.tiny0[0].originalname, 'tiny0.dat')
+      assert.strictEqual(req.files.tiny0[0].size, 122)
+      assert.strictEqual(req.files.tiny0[0].buffer.length, 122)
 
-      assert.equal(req.files['tiny1'][0].fieldname, 'tiny1')
-      assert.equal(req.files['tiny1'][0].originalname, 'tiny1.dat')
-      assert.equal(req.files['tiny1'][0].size, 7)
-      assert.equal(req.files['tiny1'][0].buffer.length, 7)
+      assert.strictEqual(req.files.tiny1[0].fieldname, 'tiny1')
+      assert.strictEqual(req.files.tiny1[0].originalname, 'tiny1.dat')
+      assert.strictEqual(req.files.tiny1[0].size, 7)
+      assert.strictEqual(req.files.tiny1[0].buffer.length, 7)
 
-      assert.equal(req.files['small0'][0].fieldname, 'small0')
-      assert.equal(req.files['small0'][0].originalname, 'small0.dat')
-      assert.equal(req.files['small0'][0].size, 1778)
-      assert.equal(req.files['small0'][0].buffer.length, 1778)
+      assert.strictEqual(req.files.small0[0].fieldname, 'small0')
+      assert.strictEqual(req.files.small0[0].originalname, 'small0.dat')
+      assert.strictEqual(req.files.small0[0].size, 1778)
+      assert.strictEqual(req.files.small0[0].buffer.length, 1778)
 
-      assert.equal(req.files['small1'][0].fieldname, 'small1')
-      assert.equal(req.files['small1'][0].originalname, 'small1.dat')
-      assert.equal(req.files['small1'][0].size, 315)
-      assert.equal(req.files['small1'][0].buffer.length, 315)
+      assert.strictEqual(req.files.small1[0].fieldname, 'small1')
+      assert.strictEqual(req.files.small1[0].originalname, 'small1.dat')
+      assert.strictEqual(req.files.small1[0].size, 315)
+      assert.strictEqual(req.files.small1[0].buffer.length, 315)
 
-      assert.equal(req.files['medium'][0].fieldname, 'medium')
-      assert.equal(req.files['medium'][0].originalname, 'medium.dat')
-      assert.equal(req.files['medium'][0].size, 13196)
-      assert.equal(req.files['medium'][0].buffer.length, 13196)
+      assert.strictEqual(req.files.medium[0].fieldname, 'medium')
+      assert.strictEqual(req.files.medium[0].originalname, 'medium.dat')
+      assert.strictEqual(req.files.medium[0].size, 13196)
+      assert.strictEqual(req.files.medium[0].buffer.length, 13196)
 
-      assert.equal(req.files['large'][0].fieldname, 'large')
-      assert.equal(req.files['large'][0].originalname, 'large.jpg')
-      assert.equal(req.files['large'][0].size, 2413677)
-      assert.equal(req.files['large'][0].buffer.length, 2413677)
+      assert.strictEqual(req.files.large[0].fieldname, 'large')
+      assert.strictEqual(req.files.large[0].originalname, 'large.jpg')
+      assert.strictEqual(req.files.large[0].size, 2413677)
+      assert.strictEqual(req.files.large[0].buffer.length, 2413677)
 
       done()
     })

--- a/test/none.js
+++ b/test/none.js
@@ -22,10 +22,10 @@ describe('None', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ok(err)
-      assert.equal(err.code, 'LIMIT_UNEXPECTED_FILE')
-      assert.equal(req.files, undefined)
-      assert.equal(req.body['key1'], 'val1')
-      assert.equal(req.body['key2'], 'val2')
+      assert.strictEqual(err.code, 'LIMIT_UNEXPECTED_FILE')
+      assert.strictEqual(req.files, undefined)
+      assert.strictEqual(req.body.key1, 'val1')
+      assert.strictEqual(req.body.key2, 'val2')
       done()
     })
   })
@@ -38,9 +38,9 @@ describe('None', function () {
 
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
-      assert.equal(req.files, undefined)
-      assert.equal(req.body['key1'], 'val1')
-      assert.equal(req.body['key2'], 'val2')
+      assert.strictEqual(req.files, undefined)
+      assert.strictEqual(req.body.key1, 'val1')
+      assert.strictEqual(req.body.key2, 'val2')
       done()
     })
   })

--- a/test/reuse-middleware.js
+++ b/test/reuse-middleware.js
@@ -30,15 +30,15 @@ describe('Reuse Middleware', function () {
       util.submitForm(parser, form, function (err, req) {
         assert.ifError(err)
 
-        assert.equal(req.body.name, 'Multer')
-        assert.equal(req.body.files, '' + fileCount)
-        assert.equal(req.files.length, fileCount)
+        assert.strictEqual(req.body.name, 'Multer')
+        assert.strictEqual(req.body.files, '' + fileCount)
+        assert.strictEqual(req.files.length, fileCount)
 
         req.files.forEach(function (file) {
-          assert.equal(file.fieldname, 'them-files')
-          assert.equal(file.originalname, 'small0.dat')
-          assert.equal(file.size, 1778)
-          assert.equal(file.buffer.length, 1778)
+          assert.strictEqual(file.fieldname, 'them-files')
+          assert.strictEqual(file.originalname, 'small0.dat')
+          assert.strictEqual(file.size, 1778)
+          assert.strictEqual(file.buffer.length, 1778)
         })
 
         if (--pending === 0) done()

--- a/test/select-field.js
+++ b/test/select-field.js
@@ -23,11 +23,11 @@ function generateForm () {
 function assertSet (files, setName, fileNames) {
   var len = fileNames.length
 
-  assert.equal(files.length, len)
+  assert.strictEqual(files.length, len)
 
   for (var i = 0; i < len; i++) {
-    assert.equal(files[i].fieldname, setName)
-    assert.equal(files[i].originalname, fileNames[i])
+    assert.strictEqual(files[i].fieldname, setName)
+    assert.strictEqual(files[i].originalname, fileNames[i])
   }
 }
 
@@ -49,16 +49,16 @@ describe('Select Field', function () {
       var file
 
       file = req.files['CA$|-|'][0]
-      assert.equal(file.fieldname, 'CA$|-|')
-      assert.equal(file.originalname, 'empty.dat')
+      assert.strictEqual(file.fieldname, 'CA$|-|')
+      assert.strictEqual(file.originalname, 'empty.dat')
 
       file = req.files['set-1'][0]
-      assert.equal(file.fieldname, 'set-1')
-      assert.equal(file.originalname, 'tiny0.dat')
+      assert.strictEqual(file.fieldname, 'set-1')
+      assert.strictEqual(file.originalname, 'tiny0.dat')
 
       file = req.files['set-2'][0]
-      assert.equal(file.fieldname, 'set-2')
-      assert.equal(file.originalname, 'tiny1.dat')
+      assert.strictEqual(file.fieldname, 'set-2')
+      assert.strictEqual(file.originalname, 'tiny1.dat')
 
       done()
     })
@@ -68,9 +68,9 @@ describe('Select Field', function () {
     util.submitForm(parser, generateForm(), function (err, req) {
       assert.ifError(err)
 
-      assertSet(req.files['CA$|-|'], 'CA$|-|', [ 'empty.dat' ])
-      assertSet(req.files['set-1'], 'set-1', [ 'tiny0.dat', 'empty.dat', 'tiny1.dat' ])
-      assertSet(req.files['set-2'], 'set-2', [ 'tiny1.dat', 'tiny0.dat', 'empty.dat' ])
+      assertSet(req.files['CA$|-|'], 'CA$|-|', ['empty.dat'])
+      assertSet(req.files['set-1'], 'set-1', ['tiny0.dat', 'empty.dat', 'tiny1.dat'])
+      assertSet(req.files['set-2'], 'set-2', ['tiny1.dat', 'tiny0.dat', 'empty.dat'])
 
       done()
     })

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -43,12 +43,12 @@ describe('Unicode', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
 
-      assert.equal(path.basename(req.file.path), filename)
-      assert.equal(req.file.originalname, filename)
+      assert.strictEqual(path.basename(req.file.path), filename)
+      assert.strictEqual(req.file.originalname, filename)
 
-      assert.equal(req.file.fieldname, 'small0')
-      assert.equal(req.file.size, 1778)
-      assert.equal(util.fileSize(req.file.path), 1778)
+      assert.strictEqual(req.file.fieldname, 'small0')
+      assert.strictEqual(req.file.size, 1778)
+      assert.strictEqual(util.fileSize(req.file.path), 1778)
 
       done()
     })


### PR DESCRIPTION
This upgrades `standard` which resolves the CI issue on Node.js 4. Of course some rules changes, especially around `assert` usage, so I made what seemed like the minimal changes for it. Since `assert.deepEqual` is deprecated and `assert.deepStrictEqual` does not exist on Node.js 0.10, I pulled in `deep-equal` so the tests were still nice and readable.