### PR TITLE
Fixes expressjs/multer#553 . Makes multer handle missing field names.

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -81,7 +81,7 @@ function makeMiddleware (setup) {
 
     // handle text field data
     busboy.on('field', function (fieldname, value, fieldnameTruncated, valueTruncated) {
-      if (!fieldname) return abortWithCode('LIMIT_MISSING_FIELD_NAME')
+      if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
       if (fieldnameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -81,6 +81,7 @@ function makeMiddleware (setup) {
 
     // handle text field data
     busboy.on('field', function (fieldname, value, fieldnameTruncated, valueTruncated) {
+      if (!fieldname) return abortWithCode('LIMIT_MISSING_FIELD_NAME')
       if (fieldnameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -7,7 +7,8 @@ var errorMessages = {
   LIMIT_FIELD_KEY: 'Field name too long',
   LIMIT_FIELD_VALUE: 'Field value too long',
   LIMIT_FIELD_COUNT: 'Too many fields',
-  LIMIT_UNEXPECTED_FILE: 'Unexpected field'
+  LIMIT_UNEXPECTED_FILE: 'Unexpected field',
+  LIMIT_MISSING_FIELD_NAME: 'Field name missing'
 }
 
 function MulterError (code, field) {

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -8,7 +8,7 @@ var errorMessages = {
   LIMIT_FIELD_VALUE: 'Field value too long',
   LIMIT_FIELD_COUNT: 'Too many fields',
   LIMIT_UNEXPECTED_FILE: 'Unexpected field',
-  LIMIT_MISSING_FIELD_NAME: 'Field name missing'
+  MISSING_FIELD_NAME: 'Field name missing'
 }
 
 function MulterError (code, field) {

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -148,6 +148,33 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should notify of missing field name', function (done) {
+    var req = new stream.PassThrough()
+    var storage = multer.memoryStorage()
+    var upload = multer({ storage: storage }).single('tiny0')
+    var boundary = 'AaB03x'
+    var body = [
+      '--' + boundary,
+      'Content-Disposition: form-data',
+      '',
+      'test content',
+      '--' + boundary,
+      ''
+    ].join('\r\n')
+
+    req.headers = {
+      'content-type': 'multipart/form-data; boundary=' + boundary,
+      'content-length': body.length
+    }
+
+    req.end(body)
+
+    upload(req, null, function (err) {
+      assert.strictEqual(err.code, 'LIMIT_MISSING_FIELD_NAME')
+      done()
+    })
+  })
+
   it('should report errors from storage engines', function (done) {
     var storage = multer.memoryStorage()
 

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -170,7 +170,7 @@ describe('Error Handling', function () {
     req.end(body)
 
     upload(req, null, function (err) {
-      assert.strictEqual(err.code, 'LIMIT_MISSING_FIELD_NAME')
+      assert.strictEqual(err.code, 'MISSING_FIELD_NAME')
       done()
     })
   })


### PR DESCRIPTION
Without this fix fields without a name result in a "TypeError: Cannot read property 'length' of undefined"
in the underlying append-field library.

The current change allows getting an error from multer that makes it
possible to handle it in servers.

See expressjs/multer#553