### PR TITLE
Remove --save from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This README is also available in other languages:
 ## Installation
 
 ```sh
-$ npm install --save multer
+$ npm install multer
 ```
 
 ## Usage


### PR DESCRIPTION
The --save option is no longer needed as of npm version 5.0.0. Just a small PR to maybe contribute a little. :smile: 
