### PR TITLE
docs: Fixes multiple misspellings and typos, improves Spanish translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ on top of [busboy](https://github.com/mscdex/busboy) for maximum efficiency.
 
 This README is also available in other languages:
 
+- [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Spanish)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chinese)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Korean)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Russian)
-- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Portuguese Brazil)
 
 ## Installation
 

--- a/doc/README-es.md
+++ b/doc/README-es.md
@@ -8,10 +8,11 @@ Multer es un "*middleware*" de node.js para el manejo de `multipart/form-data`, 
 
 Éste archivo README también está disponible en otros lenguajes:
 
-- [Engilsh] (https://github.com/expressjs/multer/blob/master/README.md)
-- [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chinese)
-- [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Korean)
-- [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Russian)
+- [Engilsh](https://github.com/expressjs/multer/blob/master/README.md) (Inglés)
+- [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chino)
+- [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Coreano)
+- [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Ruso)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Portugués Brasileño)
 
 ## Instalación
 

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -8,6 +8,7 @@ Multer는 파일 업로드를 위해 사용되는 `multipart/form-data` 를 다�
 
 이 문서는 아래의 언어로도 제공됩니다:
 - [English](https://github.com/expressjs/multer/blob/master/README.md)
+- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (스페인어)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (중국어)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (러시아)
 - [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -7,8 +7,8 @@ Multer는 파일 업로드를 위해 사용되는 `multipart/form-data` 를 다�
 ## 번역
 
 이 문서는 아래의 언어로도 제공됩니다:
-- [English](https://github.com/expressjs/multer/blob/master/README.md)
-- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (스페인어)
+- [English](https://github.com/expressjs/multer/blob/master/README.md) (영어)
+- [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (스페인어)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (중국어)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (러시아)
 - [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (포르투갈어 BR)

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -11,7 +11,7 @@ Multer는 파일 업로드를 위해 사용되는 `multipart/form-data` 를 다�
 - [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (스페인어)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (중국어)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (러시아)
-- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (포르투갈어 BR)
 
 ## 설치
 

--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -8,10 +8,11 @@ Multer é um middleware node.js para manipulação `multipart/form-data`, que é
 
 Este README também está disponível em outros idiomas:
 
-- [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chinese)
-- [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Korean)
-- [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Russian)
-- [English](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (English)
+- [English](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Inglês)
+- [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Espanhol)
+- [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chinês)
+- [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Coreano)
+- [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Russo)
 
 ## Instalação
 

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -12,7 +12,7 @@ Multer — это middleware для фреймворка express для обра
 - [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Испанский)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Китайский)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Корейский)
-- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (BR Португальский)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (бр Португальский)
 
 ## Установка
 

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -9,7 +9,7 @@ Multer — это middleware для фреймворка express для обра
 Это README также доступно на других языках:
 
 - [English](https://github.com/expressjs/multer/blob/master/README.md) (Английский)
-- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Испанский)
+- [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Испанский)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Китайский)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Корейский)
 - [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (BR Португальский)

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -9,9 +9,10 @@ Multer — это middleware для фреймворка express для обра
 Это README также доступно на других языках:
 
 - [English](https://github.com/expressjs/multer/blob/master/README.md) (Английский)
+- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Испанский)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Китайский)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Корейский)
-- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (BR Португальский)
 
 ## Установка
 

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -11,7 +11,7 @@ Multer 是一个 node.js 中间件，用于处理 `multipart/form-data` 类型�
 ## 其它语言
 
 - [English](https://github.com/expressjs/multer/blob/master/README.md) (英语)
-- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (西班牙文)
+- [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (西班牙文)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (朝鲜语)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (俄語)
 - [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (巴西葡萄牙语)

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -11,6 +11,7 @@ Multer 是一个 node.js 中间件，用于处理 `multipart/form-data` 类型�
 ## 其它语言
 
 - [English](https://github.com/expressjs/multer/blob/master/README.md) (英语)
+- [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (西班牙文)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (朝鲜语)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (俄語)
 - [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -14,7 +14,7 @@ Multer 是一个 node.js 中间件，用于处理 `multipart/form-data` 类型�
 - [Spanish](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (西班牙文)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (朝鲜语)
 - [Русский язык](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (俄語)
-- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (Português Brazil)
+- [Português](https://github.com/expressjs/multer/blob/master/doc/README-pt-br.md) (巴西葡萄牙语)
 
 ## 安装
 


### PR DESCRIPTION
Fixed typos and improved Spanish docs.
Add Spanish (Español) to README.md and other docs.
Fixed typos in Brazilian Portuguese in Translations.
Fixed other's language's docs Translations by translating Brazilian Portuguese to each docs language.
Organize the hierachy of the Translations on each docs based on README.md