### PR TITLE
Close write stream on connection error (FD leak on incomplete uploads)

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -40,9 +40,11 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       file.stream.pipe(outStream)
 
-      connection.on('error', function(error) {
-        outStream.end();
-      })
+      if (connection) {
+        connection.on('error', function(error) {
+          outStream.end();
+        })
+      }
 
       outStream.on('error', cb)
       outStream.on('finish', function () {

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -36,8 +36,14 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       var finalPath = path.join(destination, filename)
       var outStream = fs.createWriteStream(finalPath)
+      var connection = req.socket || req.connection
 
       file.stream.pipe(outStream)
+
+      connection.on('error', (error) => {
+        outStream.end();
+      })
+
       outStream.on('error', cb)
       outStream.on('finish', function () {
         cb(null, {

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -40,7 +40,7 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       file.stream.pipe(outStream)
 
-      connection.on('error', (error) => {
+      connection.on('error', function(error) {
         outStream.end();
       })
 

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -41,8 +41,9 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
       file.stream.pipe(outStream)
 
       if (connection) {
-        connection.on('error', function(error) {
-          outStream.end();
+        connection.on('error', function (error) {
+          outStream.end()
+          cb(error)
         })
       }
 


### PR DESCRIPTION
We have seen a large number of open FD's when using express with multer.

After investing, we have found the issue to be aborted uploads.

It seems the upload FD is not being closed if the client aborts the request mid-way.

## How To Reproduce
From the [readme](https://github.com/expressjs/multer#usage) (adapted to a single field):

```javascript
const express = require('express');
const multer  = require('multer');
const upload = multer({ dest: 'uploads/' });

var app = express();
var cpUpload = upload.fields([{
    name: 'avatar',
    maxCount: 1
}]);

app.post('/upload', cpUpload, function (req, res, next) {
    res.send('ok');
});

app.listen(8081, () => {
    console.log('Listening');
});
```

Using whichever client, upload a file and abort it during transit:

```bash
# make sure the file is somewhat large
# and don't forget to abort before getting the response
curl -vvv 'http://localhost:8081/upload' -F 'avatar=@file' --limit-rate 1M;
```

Finally using [lsof](https://en.wikipedia.org/wiki/Lsof) on the node process, you should see a FD leaked to the `uploads` directory

## Related(?)
* https://github.com/nodejs/node/issues/7732
    * Really old bug, closed without being solved, seems like this is is the "core" issue
* https://github.com/fastify/fastify-static/issues/116#issuecomment-655529420
    * Similar reproduction steps, but on downloading files
