### PR TITLE
Fix in multer configuration (Storage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The disk storage engine gives you full control on storing files to disk.
 ```javascript
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, '/tmp/my-uploads')
+    cb(null, 'tmp/my-uploads')
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)


### PR DESCRIPTION
I tried with settings mentioned in the README.md file.
If I use the slash like this /tmp it refers my c drive, but if I don't use slash it works.
