### PR TITLE
doc: update var to const in all Readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Don't forget the `enctype="multipart/form-data"` in your form.
 ```
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file is the `avatar` file
@@ -51,7 +51,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // req.body will contain the text fields, if there were any
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files is an object (String -> Array) where fieldname is the key, and the value is array of files
   //
@@ -66,10 +66,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 In case you need to handle a text-only multipart form, you should use the `.none()` method:
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.none(), function (req, res, next) {
   // req.body contains the text fields
@@ -91,8 +91,8 @@ Here's an example on how multer is used an HTML form. Take special note of the `
 Then in your javascript file you would add these lines to access both the file and the body. It is important that you use the `name` field value from the form in your upload function. This tells multer which field on the request it should look for the files in. If these fields aren't the same in the HTML form and on your server, your upload will fail:
 
 ```javascript
-var multer  = require('multer')
-var upload = multer({ dest: './public/data/uploads/' })
+const multer  = require('multer')
+const upload = multer({ dest: './public/data/uploads/' })
 app.post('/stats', upload.single('uploaded_file'), function (req, res) {
    // req.file is the name of your file in the form above, here 'uploaded_file'
    // req.body will hold the text fields, if there were any 
@@ -142,7 +142,7 @@ In an average web app, only `dest` might be required, and configured as shown in
 the following example.
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 
 If you want more control over your uploads, you'll want to use the `storage`
@@ -197,7 +197,7 @@ where you are handling the uploaded files.
 The disk storage engine gives you full control on storing files to disk.
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -207,7 +207,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 There are two options available, `destination` and `filename`. They are both
@@ -245,8 +245,8 @@ The memory storage engine stores the files in memory as `Buffer` objects. It
 doesn't have any options.
 
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 
 When using memory storage, the file info will contain a field called
@@ -306,8 +306,8 @@ If you want to catch errors specifically from Multer, you can call the
 middleware function by yourself. Also, if you want to catch only [the Multer errors](https://github.com/expressjs/multer/blob/master/lib/multer-error.js), you can use the `MulterError` class that is attached to the `multer` object itself (e.g. `err instanceof multer.MulterError`).
 
 ```javascript
-var multer = require('multer')
-var upload = multer().single('avatar')
+const multer = require('multer')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {

--- a/doc/README-es.md
+++ b/doc/README-es.md
@@ -34,11 +34,11 @@ No te olvides de `enctype="multipart/form-data"` en tu formulario.
 ```
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file es el `avatar` del archivo
@@ -50,7 +50,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // req.body tendrá los campos textuales, en caso de haber alguno.
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files es un objeto (String -> Array) donde el nombre del campo es la clave (key) y el valor es el arreglo (arrya) de archivos
   //
@@ -65,10 +65,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 En caso de que necesites manejar un formulario multiparte (multipart form) que sólo contiene campos de texto, recomendamos usar el método `.none()`:
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.none(), function (req, res, next) {
   // req.body contiene los campos textuales
@@ -111,7 +111,7 @@ Clave (key) | Descripción
 En la aplicación web promedio es probable que sólo se requiera `dest`, siendo configurado como en el siguiente ejemplo:
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 
 Si quieres más control sobre tus subidas, tendrás que usar la opción `storage` en vez de `dest`. Multer incorpora los mecanismos de almacenamiento `DiskStorage` y `MemoryStorage`; existen otros medios provistos por terceros.
@@ -156,7 +156,7 @@ Acepta todos los archivos que han sido enviado. Un arreglo (array) contieniendo 
 El mecanismo de almacenamiento en el disco otorga completo control en la escritura de archivos en tu disco.
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -165,7 +165,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 Hay dos opciones disponibles, `destination` y `filename`. Ambas son funciones que determinan dónde debería almacenarse el archivo.
@@ -187,8 +187,8 @@ Nota que  `req.body` puede que no haya sido totalmente poblado todavía. Esto de
 El mecanismo de almacenamiento en memoria almacena los archivos en la memoria en la forma de objetos `Buffer`. Para esto no se proveen opciones.
 
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 
 Al usar el almacenamiento en memoria, la información del archivo contendrá un campo llamado `buffer` que contiene el archivo entero.
@@ -242,8 +242,8 @@ Al encontrarse con un error, Multer delegará ese error a Express. Puedes mostra
 Si quieres atajar los errores específicamente desde Multer, puedes llamar la función middleware tú mismo. También, si quieres atajar sólo [los errores de Multer](https://github.com/expressjs/multer/blob/master/lib/multer-error.js), puedes usar la clase `MulterError` que está adherida al mismo objeto `multer` (por ejemplo: `err instanceof multer.MulterError`).
 
 ```javascript
-var multer = require('multer')
-var upload = multer().single('avatar')
+const multer = require('multer')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -25,11 +25,11 @@ Multer는 `body` 객체와 한 개의 `file` 혹은 여러개의 `files` 객체�
 기본 사용 예제:
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file 은 `avatar` 라는 필드의 파일 정보입니다.
@@ -41,7 +41,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // 텍스트 필드가 있는 경우, req.body가 이를 포함할 것입니다.
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files는 (String -> Array) 형태의 객체 입니다.
   // 필드명은 객체의 key에, 파일 정보는 배열로 value에 저장됩니다.
@@ -57,10 +57,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 텍스트 전용 multipart 폼을 처리해야 하는 경우, 어떠한 multer 메소드 (`.single()`, `.array()`, `fields()`) 도 사용할 수 있습니다. 아래는 `.array()` 를 사용한 예제 입니다 :
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.array(), function (req, res, next) {
   // req.body는 텍스트 필드를 포함합니다.
@@ -103,7 +103,7 @@ Key | Description
 보통의 웹 앱에서는 `dest` 옵션 정도만 필요할지도 모릅니다. 설정 방법은 아래의 예제에 나와있습니다.
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 
 만일 업로드를 더 제어하고 싶다면, `dest` 옵션 대신 `storage` 옵션을 사용할 수 있습니다. Multer는 스토리지 엔진인 `DiskStorage` 와 `MemoryStorage` 를 탑재하고 있습니다. 써드파티로부터 더 많은 엔진들을 사용할 수 있습니다.
@@ -147,7 +147,7 @@ var upload = multer({ dest: 'uploads/' })
 디스크 스토리지 엔진은 파일을 디스크에 저장하기 위한 모든 제어 기능을 제공합니다.
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -156,7 +156,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 `destination` 과 `filename` 의 두가지 옵션이 가능합니다. 두 옵션 모두 파일을 어디에 저장할 지를 정하는 함수입니다.
@@ -179,8 +179,8 @@ var upload = multer({ storage: storage })
 메모리 스토리지 엔진은 파일을 메모리에 `Buffer` 객체로 저장합니다. 이에 대해서는 어떤 옵션도 없습니다.
 
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 
 메모리 스토리지 사용시, 파일 정보는 파일 전체를 포함하는 `buffer` 라고 불리는 필드를 포함할 것입니다.
@@ -232,7 +232,7 @@ function fileFilter (req, file, cb) {
 만일 multer 로부터 특별히 에러를 캐치하고 싶다면, 직접 미들웨어 함수를 호출하세요.
 
 ```javascript
-var upload = multer().single('avatar')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {

--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -34,11 +34,11 @@ Não esqueça o `enctype="multipart/form-data"` em seu formulário.
 ```
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file is the `avatar` file
@@ -50,7 +50,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // req.body will contain the text fields, if there were any
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files is an object (String -> Array) where fieldname is the key, and the value is array of files
   //
@@ -65,10 +65,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 Caso você precise lidar com formulário text-only multipart, você deve usar o método `.none()`:
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.none(), function (req, res, next) {
   // req.body contains the text fields
@@ -111,7 +111,7 @@ Key | Descrição
 Em um web app básico, somente o `dest` pode ser necessário, e configurado como mostrado no exemplo a seguir:
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 
 Se você quiser mais controle sobre seus envios, você ter que usar a opção `storage` em vez de `dest`. Multer vem com motores de armazenamento `DiskStorage` e `MemoryStorage`; Mais mecanismos estão disponíveis de terceiros.
@@ -159,7 +159,7 @@ Nunca adicione o Multer como global no middleware, já que um usuário mal-inten
 O mecanismo de armazenamento em disco oferece controle total sobre o armazenamento de arquivos em disco.
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -168,7 +168,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 Existem duas opções disponíveis, `destination` e `filename`. Ambas são funções que determinam onde o arquivo deve ser armazenado.
@@ -190,8 +190,8 @@ Observe que `req.body` pode não ter sido totalmente preenchido ainda. Isso depe
 
 O mecanismo de armazenamento na memória, armazena os arquivos na memória como um objeto `Buffer`. Não tendo opções.
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 Ao usar o armazenamento de memória, as informações do arquivo conterão um campo chamado `buffer` que contém o arquivo inteiro.
 
@@ -246,8 +246,8 @@ Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibi
 Se você quer pegar erros especificamente do Multer, você pode enviar para o função de middleware. Além disso, se você quiser pegar apenas [os erros do Multer](https://github.com/expressjs/multer/blob/master/lib/multer-error.js), você pode usar a classe `MulterError` que está ligado ao objeto `multer` (e.g. `err instanceof multer.MulterError`).
 
 ```javascript
-var multer = require('multer')
-var upload = multer().single('avatar')
+const multer = require('multer')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -34,11 +34,11 @@ Multer добавляет объект `body` и объект `file` (или `fi
 ```
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file - файл `avatar`
@@ -50,7 +50,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // req.body сохранит текстовые поля, если они будут
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files - объект (String -> Array), где fieldname - ключ, и значение - массив файлов
   //
@@ -65,10 +65,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 Если вам нужно обработать multipart-форму, содержащую только текст, используйте метод `.none()`:
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.none(), function (req, res, next) {
   // req.body содержит текстовые поля
@@ -111,7 +111,7 @@ Multer принимает объект с опциями. Базовая опц�
 Обычно для веб-приложения нужно обязательно переопределить `dest`, как показано в примере ниже.
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 Если вам нужно больше возможностей для управления приложением, можно использовать `storage` вместо `dest`. Multer поставляется с двумя движками работы с памятью, `DiskStorage` и `MemoryStorage`, другие движки можно найти у сторонних разработчиков.
 
@@ -154,7 +154,7 @@ var upload = multer({ dest: 'uploads/' })
 Движок дискового пространства. Дает полный контроль над размещением файлов на диск. 
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -163,7 +163,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 Доступно две опции, расположение `destination` и имя файла `filename`. Обе эти функции определяют, где будет находиться файл после загрузки. 
@@ -186,8 +186,8 @@ var upload = multer({ storage: storage })
 Движок оперативной памяти сохраняет файлы в памяти как объекты типа `Buffer`. В этом случае нет никаких дополнительных опций.
 
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 Когда вы используете этот тип передачи, информация о файле будет содержать поле `buffer`, которое содержит весь файл. 
 
@@ -241,8 +241,8 @@ function fileFilter (req, file, cb) {
 Если вы хотите отлавливать ошибки конкретно от Multer, вам нужно вызывать собственную middleware для их обработки. Еще, если вы хотите отлавливать [исключительно ошибки Multer](https://github.com/expressjs/multer/blob/master/lib/make-error.js#L1-L9), вы можете использовать класс `MulterError`, который привязан к объекту `multer` (например, `err instanceof multer.MulterError`)
 
 ```javascript
-var multer = require('multer')
-var upload = multer().single('avatar')
+const multer = require('multer')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -29,11 +29,11 @@ Multer 会添加一个 `body` 对象 以及 `file` 或 `files` 对象 到 expres
 基本使用方法:
 
 ```javascript
-var express = require('express')
-var multer  = require('multer')
-var upload = multer({ dest: 'uploads/' })
+const express = require('express')
+const multer  = require('multer')
+const upload = multer({ dest: 'uploads/' })
 
-var app = express()
+const app = express()
 
 app.post('/profile', upload.single('avatar'), function (req, res, next) {
   // req.file 是 `avatar` 文件的信息
@@ -45,7 +45,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
   // req.body 将具有文本域数据，如果存在的话
 })
 
-var cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
+const cpUpload = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', cpUpload, function (req, res, next) {
   // req.files 是一个对象 (String -> Array) 键是文件名，值是文件数组
   //
@@ -60,10 +60,10 @@ app.post('/cool-profile', cpUpload, function (req, res, next) {
 如果你需要处理一个只有文本域的表单，你应当使用 `.none()`:
 
 ```javascript
-var express = require('express')
-var app = express()
-var multer  = require('multer')
-var upload = multer()
+const express = require('express')
+const app = express()
+const multer  = require('multer')
+const upload = multer()
 
 app.post('/profile', upload.none(), function (req, res, next) {
   // req.body 包含文本域
@@ -106,7 +106,7 @@ Key | Description
 通常，一般的网页应用，只需要设置 `dest` 属性，像这样：
 
 ```javascript
-var upload = multer({ dest: 'uploads/' })
+const upload = multer({ dest: 'uploads/' })
 ```
 
 如果你想在上传时进行更多的控制，你可以使用 `storage` 选项替代 `dest`。Multer 具有 `DiskStorage` 和 `MemoryStorage` 两个存储引擎；另外还可以从第三方获得更多可用的引擎。
@@ -152,7 +152,7 @@ Example:
 磁盘存储引擎可以让你控制文件的存储。
 
 ```javascript
-var storage = multer.diskStorage({
+const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
@@ -161,7 +161,7 @@ var storage = multer.diskStorage({
   }
 })
 
-var upload = multer({ storage: storage })
+const upload = multer({ storage: storage })
 ```
 
 有两个选项可用，`destination` 和 `filename`。他们都是用来确定文件存储位置的函数。
@@ -183,8 +183,8 @@ var upload = multer({ storage: storage })
 内存存储引擎将文件存储在内存中的 `Buffer` 对象，它没有任何选项。
 
 ```javascript
-var storage = multer.memoryStorage()
-var upload = multer({ storage: storage })
+const storage = multer.memoryStorage()
+const upload = multer({ storage: storage })
 ```
 
 当使用内存存储引擎，文件信息将包含一个 `buffer` 字段，里面包含了整个文件数据。
@@ -236,8 +236,8 @@ function fileFilter (req, file, cb) {
 如果你想捕捉 multer 发出的错误，你可以自己调用中间件程序。如果你想捕捉 [Multer 错误](https://github.com/expressjs/multer/blob/master/lib/multer-error.js)，你可以使用 `multer` 对象下的 `MulterError` 类 (即 `err instanceof multer.MulterError`)。
 
 ```javascript
-var multer = require('multer')
-var upload = multer().single('avatar')
+const multer = require('multer')
+const upload = multer().single('avatar')
 
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {


### PR DESCRIPTION
Update `var` to `const` in Readme and all translations. This was done with a search replace on each document, I believe but did not verify that all code examples are the same in all translations. 

Interestingly though, I think the English readme might have an extra codeblock that the others don't. Someone should check the blame and see if we need to update the translations with an example. Although I guess we would then need to translate that example haha. 

Edit: [Found it](https://github.com/expressjs/multer/pull/580) and it's of course something I reviewed. Looking back at it, I'm not sure that example was necessary. I think it just repeats the example above it. Maybe the elaborated explanation should get moved up.

closes #1012 