### PR TITLE
add parseJsonFields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Key | Description
 `dest` or `storage` | Where to store the files
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
+`parseJsonFields` | Parse fields that have the content-type `application/json`
 `preservePath` | Keep the full path of files instead of just the base name
 
 In an average web app, only `dest` might be required, and configured as shown in
@@ -303,6 +304,13 @@ function fileFilter (req, file, cb) {
 
 }
 ```
+
+### `parseJsonFields`
+
+Fields may also have a `Content-Type` header. If you set `parseJsonFields` to
+`true` these fields will be parsed using `JSON.parse()` instead of handled as
+plain text strings. This way you don't need to unroll complex JSON structures
+that are transmitted alongside uploaded files as url-encoded fields.
 
 ## Error handling
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function Multer (options) {
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
+  this.parseJsonFields = !!options.parseJsonFields
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,7 +50,8 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
-      fileStrategy: fileStrategy
+      fileStrategy: fileStrategy,
+      parseJsonFields: this.parseJsonFields
     }
   }
 
@@ -79,7 +81,8 @@ Multer.prototype.any = function () {
       preservePath: this.preservePath,
       storage: this.storage,
       fileFilter: this.fileFilter,
-      fileStrategy: 'ARRAY'
+      fileStrategy: 'ARRAY',
+      parseJsonFields: this.parseJsonFields
     }
   }
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -25,6 +25,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var parseJsonFields = options.parseJsonFields
 
     req.body = Object.create(null)
 
@@ -86,7 +87,7 @@ function makeMiddleware (setup) {
     }
 
     // handle text field data
-    busboy.on('field', function (fieldname, value, { nameTruncated, valueTruncated }) {
+    busboy.on('field', function (fieldname, value, { nameTruncated, valueTruncated, mimeType }) {
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
       if (nameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
@@ -94,6 +95,14 @@ function makeMiddleware (setup) {
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
+      }
+
+      if (parseJsonFields && mimeType === 'application/json') {
+        try {
+          value = JSON.parse(value)
+        } catch (error) {
+          return abortWithError(error)
+        }
       }
 
       appendField(req.body, fieldname, value)


### PR DESCRIPTION
Fields may also have a `Content-Type` header. If you set `parseJsonFields` to
`true` these fields will be parsed using `JSON.parse()` instead of handled as
plain text strings. This way you don't need to unroll complex JSON structures
that are transmitted alongside uploaded files as url-encoded fields.

If this is not good for some reason I'd at least like to have some way to get
what the content-type of the field was in the request handler, so I can at least
handle that situation manually.

A possible extension: Make it `parseFields` instead and not just handle
`application/json` content-types, but also fields with a
`application/x-www-form-urlencoded` content-type, or instead of a boolean
flag make it possible to pass a filter function (`value = fieldFilter(value, mimetype)`).
An advantage to the filter function approach would be the possibility to throw
a custom error type which can be handled more specifically than a `SyntaxError`
in the servers error handler.