### PR TITLE
fix bug where next() is not called, which breaks cls-hooked (express-http-context)

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -174,6 +174,7 @@ function makeMiddleware (setup) {
     })
 
     req.pipe(busboy)
+    next()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "1.4.3",
+  "version": "1.4.4-rc1chg",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",


### PR DESCRIPTION
See https://github.com/expressjs/multer/issues/1046 