### PR TITLE
Added support for JSON fields for parity with Axios;

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -9,6 +9,14 @@ var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
 
+var endsWith = (function (endsWith) {
+  return endsWith ? function (str, ending) {
+    return endsWith.call(str, ending)
+  } : function (str, ending) {
+    return str.slice(-ending.length) === ending
+  }
+})(String.prototype.endsWith)
+
 function drainStream (stream) {
   stream.on('readable', stream.read.bind(stream))
 }
@@ -24,6 +32,9 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var jsonFields = options.jsonFields
+
+    if (typeof jsonFields === 'undefined') jsonFields = true
 
     req.body = Object.create(null)
 
@@ -88,6 +99,15 @@ function makeMiddleware (setup) {
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
+      }
+
+      if (jsonFields && endsWith(fieldname, '{}')) {
+        try {
+          req.body[fieldname.slice(0, -2)] = JSON.parse(value)
+          return
+        } catch (err) {
+          return abortWithCode('BAD_JSON_VALUE', fieldname)
+        }
       }
 
       appendField(req.body, fieldname, value)

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -8,7 +8,8 @@ var errorMessages = {
   LIMIT_FIELD_VALUE: 'Field value too long',
   LIMIT_FIELD_COUNT: 'Too many fields',
   LIMIT_UNEXPECTED_FILE: 'Unexpected field',
-  MISSING_FIELD_NAME: 'Field name missing'
+  MISSING_FIELD_NAME: 'Field name missing',
+  BAD_JSON_VALUE: 'JSON parsing failed'
 }
 
 function MulterError (code, field) {

--- a/test/fields.js
+++ b/test/fields.js
@@ -132,4 +132,23 @@ describe('Fields', function () {
       done()
     })
   })
+
+  it('should convert JSON fields into objects', function (done) {
+    var form = new FormData()
+
+    form.append('obj{}', JSON.stringify({
+      x: 1, foo: 'bar'
+    }))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert(deepEqual(req.body, {
+        obj: {
+          x: 1,
+          foo: 'bar'
+        }
+      }))
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Since `v0.27.2` Axios [supports](https://github.com/axios/axios#-automatic-serialization) FormData serializer that encodes object fields with `{}` ending to a JSON string. So this PR adds the ability to parse such fields by multer.
```js
await axios.postForm('http://localhost/', {
  str: 'Jay"
  'obj{}': {x:1, foo: 'bar'},
  'files[]': document.querySelector('#myFile').files
});
```
Will be stored as `req.body.obj`
 