### PR TITLE
#790 bump busboy up to solve encoding bug

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -30,7 +30,7 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      busboy = Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }
@@ -80,9 +80,9 @@ function makeMiddleware (setup) {
     }
 
     // handle text field data
-    busboy.on('field', function (fieldname, value, fieldnameTruncated, valueTruncated) {
+    busboy.on('field', function (fieldname, value, {nameTruncated, valueTruncated}) {
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
-      if (fieldnameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
+      if (nameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
@@ -94,7 +94,7 @@ function makeMiddleware (setup) {
     })
 
     // handle files
-    busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
+    busboy.on('file', function (fieldname, fileStream, {filename, encoding, mimeType}) {
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
@@ -107,7 +107,7 @@ function makeMiddleware (setup) {
         fieldname: fieldname,
         originalname: filename,
         encoding: encoding,
-        mimetype: mimetype
+        mimetype: mimeType
       }
 
       var placeholder = appender.insertPlaceholder(file)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "append-field": "^1.0.0",
-    "busboy": "^0.2.11",
+    "busboy": "^1.6.0",
     "concat-stream": "^1.5.2",
     "mkdirp": "^0.5.4",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
busboy in package json version(^0.2.11 = 0.2.14) does not handle multi fields in content-disposition.
so i bump up the version and fix all minor api breaking changes of busboy.