### PR TITLE
fix: app crash

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -49,6 +49,7 @@ function makeMiddleware (setup) {
       req.unpipe(busboy)
       drainStream(req)
       busboy.removeAllListeners()
+      busboy.on('error', function (err) { })
 
       onFinished(req, function () { next(err) })
     }


### PR DESCRIPTION
During stream termination, errors can occur which can crash the entire application, since all the listeners on the busboy are removed. We suppress such errors with this fix. 

Scenario: If Dicer didn't fully parse the content and the stream terminates (for example after failing to pass the fileFilter), Dicer sends an error event ([link](https://github.com/mscdex/dicer/blob/master/lib/Dicer.js#L68)). This event goes to Busboy ([link](https://github.com/mscdex/busboy/blob/v0.2.14/lib/types/multipart.js#L281)) and then crashes because all listeners have been deleted. 

This will potentially fix it: [1](https://github.com/expressjs/multer/issues/350) [2](https://github.com/nestjs/nest/issues/9489)
