### PR TITLE
bump busboy up to solve DoS vulnerability

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -30,7 +30,7 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      busboy = Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }
@@ -80,9 +80,9 @@ function makeMiddleware (setup) {
     }
 
     // handle text field data
-    busboy.on('field', function (fieldname, value, fieldnameTruncated, valueTruncated) {
+    busboy.on('field', function (fieldname, value, { nameTruncated, valueTruncated }) {
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
-      if (fieldnameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
+      if (nameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
@@ -94,7 +94,7 @@ function makeMiddleware (setup) {
     })
 
     // handle files
-    busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
+    busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
@@ -107,7 +107,7 @@ function makeMiddleware (setup) {
         fieldname: fieldname,
         originalname: filename,
         encoding: encoding,
-        mimetype: mimetype
+        mimetype: mimeType
       }
 
       var placeholder = appender.insertPlaceholder(file)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "append-field": "^1.0.0",
-    "busboy": "^0.2.11",
+    "busboy": "^1.0.0",
     "concat-stream": "^1.5.2",
     "mkdirp": "^0.5.4",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
Hello,

Snyk is reporting a vulnerability in this repo, that is coming from the Dicer library:

```
Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JS-DICER-2311764] in dicer@0.2.5
    introduced by multer@1.4.4 > busboy@0.2.14 > dicer@0.2.5
  No upgrade or patch available
```

This change removes dicer from multer's transitive dependency list.