### PR TITLE
fix(cve): bump busboy to fix CVE-2022-24434

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -1,17 +1,12 @@
 var is = require('type-is')
 var Busboy = require('busboy')
 var extend = require('xtend')
-var onFinished = require('on-finished')
 var appendField = require('append-field')
 
 var Counter = require('./counter')
 var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
-
-function drainStream (stream) {
-  stream.on('readable', stream.read.bind(stream))
-}
 
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
@@ -30,7 +25,7 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      busboy = Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }
@@ -45,12 +40,9 @@ function makeMiddleware (setup) {
     function done (err) {
       if (isDone) return
       isDone = true
-
       req.unpipe(busboy)
-      drainStream(req)
       busboy.removeAllListeners()
-
-      onFinished(req, function () { next(err) })
+      next(err)
     }
 
     function indicateDone () {
@@ -80,9 +72,9 @@ function makeMiddleware (setup) {
     }
 
     // handle text field data
-    busboy.on('field', function (fieldname, value, fieldnameTruncated, valueTruncated) {
+    busboy.on('field', function (fieldname, value, { nameTruncated, valueTruncated }) {
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
-      if (fieldnameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
+      if (nameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
@@ -94,7 +86,7 @@ function makeMiddleware (setup) {
     })
 
     // handle files
-    busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
+    busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
@@ -107,7 +99,7 @@ function makeMiddleware (setup) {
         fieldname: fieldname,
         originalname: filename,
         encoding: encoding,
-        mimetype: mimetype
+        mimetype: mimeType
       }
 
       var placeholder = appender.insertPlaceholder(file)
@@ -169,7 +161,7 @@ function makeMiddleware (setup) {
     busboy.on('partsLimit', function () { abortWithCode('LIMIT_PART_COUNT') })
     busboy.on('filesLimit', function () { abortWithCode('LIMIT_FILE_COUNT') })
     busboy.on('fieldsLimit', function () { abortWithCode('LIMIT_FIELD_COUNT') })
-    busboy.on('finish', function () {
+    busboy.on('close', function () {
       readFinished = true
       indicateDone()
     })

--- a/package.json
+++ b/package.json
@@ -20,11 +20,10 @@
   ],
   "dependencies": {
     "append-field": "^1.0.0",
-    "busboy": "^0.2.11",
+    "busboy": "^1.0.0",
     "concat-stream": "^1.5.2",
     "mkdirp": "^0.5.4",
     "object-assign": "^4.1.1",
-    "on-finished": "^2.3.0",
     "type-is": "^1.6.4",
     "xtend": "^4.0.0"
   },
@@ -39,7 +38,7 @@
     "testdata-w3c-json-form": "^1.0.0"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.0.0"
   },
   "files": [
     "LICENSE",

--- a/test/_util.js
+++ b/test/_util.js
@@ -1,7 +1,6 @@
 var fs = require('fs')
 var path = require('path')
 var stream = require('stream')
-var onFinished = require('on-finished')
 
 exports.file = function file (name) {
   return fs.createReadStream(path.join(__dirname, 'files', name))
@@ -17,11 +16,6 @@ exports.submitForm = function submitForm (multer, form, cb) {
 
     var req = new stream.PassThrough()
 
-    req.complete = false
-    form.once('end', function () {
-      req.complete = true
-    })
-
     form.pipe(req)
     req.headers = {
       'content-type': 'multipart/form-data; boundary=' + form.getBoundary(),
@@ -29,7 +23,7 @@ exports.submitForm = function submitForm (multer, form, cb) {
     }
 
     multer(req, null, function (err) {
-      onFinished(req, function () { cb(err, req) })
+      cb(err, req)
     })
   })
 }

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -244,7 +244,7 @@ describe('Error Handling', function () {
     req.end(body)
 
     upload(req, null, function (err) {
-      assert.strictEqual(err.message, 'Unexpected end of multipart data')
+      assert.strictEqual(err.message, 'Unexpected end of form')
       done()
     })
   })

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -8,7 +8,6 @@ var util = require('./_util')
 var express = require('express')
 var FormData = require('form-data')
 var concat = require('concat-stream')
-var onFinished = require('on-finished')
 
 var port = 34279
 
@@ -27,7 +26,7 @@ describe('Express Integration', function () {
     req.on('response', function (res) {
       res.on('error', cb)
       res.pipe(concat({ encoding: 'buffer' }, function (body) {
-        onFinished(req, function () { cb(null, res, body) })
+        cb(null, res, body)
       }))
     })
   }


### PR DESCRIPTION
This PR bumps `busboy` to at least `1.0.0` to remove `dicer` from the transitive dependencies as it contains a denial of service vulnerability: https://security.snyk.io/vuln/SNYK-JS-DICER-2311764.

The remaining of the PR is about adapting the code to the breaking changes introduced in `busboy` with the bump to `v1` and fixing the tests:
- reverted https://github.com/expressjs/multer/pull/205 to fix `should report errors from busboy parsing` test as the error was no longer forwarded. I have not really looked into the details but reverting this workaround for an issue related to Node v0 seems like a win anyway,
- updated `should handle unicode filenames` test to have a more pertinent example of a unicode filename using both `filename` and `filename*` `Content-Disposition` directives.

This PR supersedes: https://github.com/expressjs/multer/pull/1096, https://github.com/expressjs/multer/pull/1092 and https://github.com/expressjs/multer/pull/1056.