### PR TITLE
Added support for  busboy configuration parameters; 'defCharset', 'defParamCharset', 'highWaterMark' and 'fileHwm'

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,14 @@ The following are the options that can be passed to Multer.
 
 Key | Description
 --- | ---
-`dest` or `storage` | Where to store the files
-`fileFilter` | Function to control which files are accepted
-`limits` | Limits of the uploaded data
-`preservePath` | Keep the full path of files instead of just the base name
+`dest` or `storage` | Where to store the files.
+`fileFilter` | Function to control which files are accepted.
+`limits` | Limits of the uploaded data. **Defaults:** check [busboy's page](https://github.com/mscdex/busboy#exports)
+`preservePath` | Keep the full path of files instead of just the base name. **Default:** check [busboy's page](https://github.com/mscdex/busboy#exports)
+`charset` | Character set to use when one isn't defined. Sets busboy's option `defCharset`. **Default:** `utf-8`. List of [available charsets](https://github.com/mscdex/busboy/blob/master/lib/utils.js#L384)
+`paramCharset` | For multipart forms, the default character set to use for values of part header parameters (e.g. filename) that are not extended parameters (that contain an explicit charset). Sets busboy's option `defParamCharset`. **Default:** `utf-8`. List of [available charsets](https://github.com/mscdex/busboy/blob/master/lib/utils.js#L384).
+`writableHVM` | Node Stream highWaterMark to use for the parser stream. Sets busboy's option `highWaterMark`. **Default:** check [busboy's page](https://github.com/mscdex/busboy#exports)
+`readableHVM` | Node Stream highWaterMark to use for individual file streams. Sets busboy's option `fileHwm`. **Default:** check [busboy's page](https://github.com/mscdex/busboy#exports)
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.
@@ -260,7 +264,7 @@ memory storage is used.
 
 ### `limits`
 
-An object specifying the size limits of the following optional properties. Multer passes this object into busboy directly, and the details of the properties can be found on [busboy's page](https://github.com/mscdex/busboy#busboy-methods).
+An object specifying the size limits of the following optional properties. Multer passes this object into busboy directly, and the details of the properties can be found on [busboy's page](https://github.com/mscdex/busboy#exports).
 
 The following integer values are available:
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function Multer (options) {
   }
 
   this.limits = options.limits
+  this.charset = typeof options.charset === 'string' ? options.charset : 'utf-8'
+  this.paramCharset = typeof options.paramCharset === 'string' ? options.paramCharset : 'utf-8'
+  this.writableHVM = options.writableHVM
+  this.readableHVM = options.readableHVM
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
 }
@@ -48,6 +52,10 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       limits: this.limits,
       preservePath: this.preservePath,
       storage: this.storage,
+      charset: this.charset,
+      paramCharset: this.paramCharset,
+      writableHVM: this.writableHVM,
+      readableHVM: this.readableHVM,
       fileFilter: wrappedFileFilter,
       fileStrategy: fileStrategy
     }

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -24,13 +24,24 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
-
+    var charset = options.charset
+    var paramCharset = options.paramCharset
+    var writableHVM = options.writableHVM
+    var readableHVM = options.readableHVM
     req.body = Object.create(null)
 
     var busboy
 
     try {
-      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      busboy = new Busboy({
+        headers: req.headers,
+        limits: limits,
+        preservePath: preservePath,
+        defCharset: charset,
+        defParamCharset: paramCharset,
+        fileHwm: readableHVM,
+        highWaterMark: writableHVM
+      })
     } catch (err) {
       return next(err)
     }


### PR DESCRIPTION
Hi,

I added support for these busboy configuration paramters. Reason for this is that I need ' defParamCharset' override from `latin1` to `utf-8`. We have busboy 1.6.0 in our project and busboy has changed filename parsing from utf-8 to latin1 and it broke our application. Our Multer version is `1.4.5-lts.1` so these changes should be release on the lts side as well.

I would not like to add `iconv-lite` package to our application, I would prefer Multer to allow to set these properties.

I tried to upgrade busboy to 1.6.0 in Multer, but it broke too many unit tests (30+). I changed `test/unicode.js` to use filename `åäöèøßð.dat` and with busboy 1.6.0 result will be `aÌaÌoÌeÌÃ¸ÃÃ°.dat` and it can be fixed by adding busboy configuration `defParamCharset = 'utf-8'`

Fixes:
#320 
#846 