### PR TITLE
fix: wrap middleware in promise

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -14,7 +14,7 @@ function drainStream (stream) {
 }
 
 function makeMiddleware (setup) {
-  return function multerMiddleware (req, res, next) {
+  function multerMiddleware (req, res, next) {
     if (!is(req, ['multipart'])) return next()
 
     var options = setup()
@@ -175,6 +175,17 @@ function makeMiddleware (setup) {
     })
 
     req.pipe(busboy)
+  }
+  return function (req, res, next) {
+    const promise = new Promise((resolve, reject) => {
+      multerMiddleware(req, res, (error) => {
+        if (error) return reject(error)
+        return resolve()
+      })
+    })
+    promise
+      .then(next)
+      .catch(error => next(error))
   }
 }
 


### PR DESCRIPTION
this is necessary, so that async hooks work

#814
#1046