### PR TITLE
fix: MEMORY LEAK

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -42,10 +42,16 @@ function makeMiddleware (setup) {
     var pendingWrites = new Counter()
     var uploadedFiles = []
 
+    function requestError(error) {
+      if(!busboy) return
+      busboy.destroy(error)
+    }
+    
     function done (err) {
       if (isDone) return
       isDone = true
 
+      req.removeEventListener('error', requestError)
       req.unpipe(busboy)
       drainStream(req)
       busboy.removeAllListeners()
@@ -174,6 +180,7 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
+    req.on('error', requestError)
     req.pipe(busboy)
   }
 }

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -51,7 +51,7 @@ function makeMiddleware (setup) {
       if (isDone) return
       isDone = true
 
-      req.removeEventListener('error', requestError)
+      req.removeListener('error', requestError)
       req.unpipe(busboy)
       drainStream(req)
       busboy.removeAllListeners()


### PR DESCRIPTION
One important caveat was ignored by piping request stream to busboy stream. This commit aknowledges that caveat by closing busboy stream when request stream encounters an error. More information about this caveat can be found on https://nodejs.org/api/stream.html#readablepipedestination-options.
> One important caveat is that if the Readable stream emits an error during processing, the Writable destination is not closed automatically. If an error occurs, it will be necessary to manually close each stream in order to prevent memory leaks.

This PR also fixes multiple issues that are caused by this caveat some are listed blow.
- #259
- #256
- #38
- (maybe) #53
- (maybe) #1058

Some PR's (that may introduce breaking changes) are closed by this PR also (without breaking changes) and some are listed blow.
- #1117
- #971
- #438
- #429

**PLEASE MERGE THIS BECAUSE IT'S INSANE ANNOYING HAVING TO RELAUNCH THE SERVER EVERY DAY BECAUSE THOUSANDS OF OPEN STREAMS ARE NOT CLOSED (MEMORY LEAKS)**

@LinusU here is a not breaking change that will fix all the above.