### PR TITLE
fix: preserve async hooks context in supported environments

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -15,6 +15,13 @@ function drainStream (stream) {
 
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
+    // If we are in a node environment that supports async_hooks, preserve
+    // the current async context.
+    try {
+      var asyncHooks = require('node:async_hooks')
+      next = asyncHooks.AsyncResource.bind(next)
+    } catch (_) {}
+
     if (!is(req, ['multipart'])) return next()
 
     var options = setup()

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -1,4 +1,5 @@
 var is = require('type-is')
+var AsyncResource = require('async_hooks').AsyncResource
 var Busboy = require('busboy')
 var appendField = require('append-field')
 
@@ -15,12 +16,15 @@ function drainStream (stream) {
 
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
-    // If we are in a node environment that supports async_hooks, preserve
-    // the current async context.
-    try {
-      var asyncHooks = require('node:async_hooks')
-      next = asyncHooks.AsyncResource.bind(next)
-    } catch (_) {}
+    // Preserve the caller's async context (AsyncLocalStorage, CLS) across the
+    // busboy stream events that eventually call next(). runInAsyncScope exists
+    // since Node 9 and passes arguments through on every version, unlike the
+    // static AsyncResource.bind, which drops them on Node 14.
+    var resource = new AsyncResource('multer')
+    var originalNext = next
+    next = function (err) {
+      resource.runInAsyncScope(originalNext, null, err)
+    }
 
     if (!is(req, ['multipart'])) return next()
 

--- a/test/functionality.js
+++ b/test/functionality.js
@@ -134,4 +134,27 @@ describe('Functionality', function () {
       done()
     })
   })
+
+  it('should preserve async_hooks context', function (done) {
+    makeStandardEnv(function (err, env) {
+      if (err) return done(err)
+
+      var parser = env.upload.single('small0')
+      env.form.append('small0', util.file('small0.dat'))
+
+      try {
+        var asyncHooks = require('node:async_hooks')
+        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        asyncLocalStorage.run('foo', function () {
+          util.submitForm(parser, env.form, function (err, req) {
+            assert.ifError(err)
+            assert.strictEqual(asyncLocalStorage.getStore(), 'foo')
+            done()
+          })
+        })
+      } catch (_) {
+        // don't test async_hooks functionality in environments that don't support it
+      }
+    })
+  })
 })

--- a/test/functionality.js
+++ b/test/functionality.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert')
+var asyncHooks = require('async_hooks')
 
 var path = require('path')
 
@@ -138,26 +139,22 @@ describe('Functionality', function () {
     })
   })
 
-  it('should preserve async_hooks context', function (done) {
+  var itWithAsyncLocalStorage = asyncHooks.AsyncLocalStorage ? it : it.skip
+  itWithAsyncLocalStorage('should preserve async_hooks context', function (done) {
     makeStandardEnv(function (err, env) {
       if (err) return done(err)
 
       var parser = env.upload.single('small0')
       env.form.append('small0', util.file('small0.dat'))
 
-      try {
-        var asyncHooks = require('node:async_hooks')
-        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
-        asyncLocalStorage.run('foo', function () {
-          util.submitForm(parser, env.form, function (err, req) {
-            assert.ifError(err)
-            assert.strictEqual(asyncLocalStorage.getStore(), 'foo')
-            done()
-          })
+      var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+      asyncLocalStorage.run('foo', function () {
+        util.submitForm(parser, env.form, function (err, req) {
+          assert.ifError(err)
+          assert.strictEqual(asyncLocalStorage.getStore(), 'foo')
+          done()
         })
-      } catch (_) {
-        // don't test async_hooks functionality in environments that don't support it
-      }
+      })
     })
   })
 })


### PR DESCRIPTION
Hey, I took another attempt at fixing multer's support for `AsyncLocalStorage`.

I believe this addresses the feedback in #1119.

Fixes #814
Fixes #1046