### PR TITLE
feat: accept a function for limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Accept a function for `limits`, called with the request, to set limits per request ([#1133](https://github.com/expressjs/multer/pull/1133))
 - Files skipped by `fileFilter` no longer count towards `maxCount` ([#1426](https://github.com/expressjs/multer/pull/1426))
 - Accept requests with exactly `limits.parts` parts; `LIMIT_PART_COUNT` now fires only when the limit is exceeded. If you set `parts` one higher to work around this, you can drop the extra one ([#1446](https://github.com/expressjs/multer/pull/1446))
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,21 @@ memory storage is used.
 
 An object specifying the size limits of the following optional properties. Multer passes this object into busboy directly, and the details of the properties can be found on [busboy's page](https://github.com/mscdex/busboy#exports).
 
+`limits` can also be a function that receives the request and returns such an
+object. It is called once per request, before parsing starts, so limits can
+depend on e.g. the authenticated user:
+
+```javascript
+const upload = multer({
+  limits: function (req) {
+    return { fileSize: req.user.maxUploadSize }
+  }
+})
+```
+
+Limits apply to the whole request; there is no per-file limit. To restrict
+individual files by type or name, use `fileFilter` or a custom storage engine.
+
 The following integer values are available:
 
 Key | Description | Default

--- a/index.js
+++ b/index.js
@@ -3,22 +3,10 @@ var makeMiddleware = require('./lib/make-middleware')
 var diskStorage = require('./storage/disk')
 var memoryStorage = require('./storage/memory')
 var MulterError = require('./lib/multer-error')
+var validateLimits = require('./lib/validate-limits')
 
 function allowAll (req, file, cb) {
   cb(null, true)
-}
-
-// busboy compares most limits with strict equality, so a non-integer value
-// never matches and silently disables the limit. Reject such values up front.
-function validateLimits (limits) {
-  Object.keys(limits).forEach(function (key) {
-    var value = limits[key]
-
-    if (value == null) return
-    if ((Number.isInteger(value) && value >= 0) || value === Infinity) return
-
-    throw new TypeError('Expected limits.' + key + ' to be a non-negative integer or Infinity')
-  })
 }
 
 function Multer (options) {
@@ -30,7 +18,7 @@ function Multer (options) {
     this.storage = memoryStorage()
   }
 
-  if (options.limits) validateLimits(options.limits)
+  if (options.limits && typeof options.limits !== 'function') validateLimits(options.limits)
 
   this.limits = options.limits
   this.preservePath = options.preservePath

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -28,8 +28,8 @@ function makeMiddleware (setup) {
     req.body = Object.create(null)
 
     if (limits) {
-      limits = {...limits}
       if (typeof limits.fileSize === 'function') {
+        limits = {...limits};
         limits.fileSize = limits.fileSize(req);
       }
     }

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -27,6 +27,13 @@ function makeMiddleware (setup) {
 
     req.body = Object.create(null)
 
+    if (limits) {
+      limits = {...limits}
+      if (typeof limits.fileSize === 'function') {
+        limits.fileSize = limits.fileSize(req);
+      }
+    }
+    
     var busboy
 
     try {

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -7,6 +7,7 @@ var Counter = require('./counter')
 var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
+var validateLimits = require('./validate-limits')
 
 // append-field turns a bracket group whose contents are all digits into an
 // array index, so `a[3]` produces an array of length 4. The index itself is
@@ -70,6 +71,17 @@ function makeMiddleware (setup) {
     var options = setup()
 
     var limits = options.limits
+
+    // limits can be a function of the request, evaluated once per request
+    if (typeof limits === 'function') {
+      try {
+        limits = limits(req)
+        if (limits) validateLimits(limits)
+      } catch (err) {
+        return next(err)
+      }
+    }
+
     var busboyLimits = limits
 
     // busboy fires 'limit' when the file size reaches limits.fileSize and

--- a/lib/validate-limits.js
+++ b/lib/validate-limits.js
@@ -1,0 +1,14 @@
+// busboy compares most limits with strict equality, so a non-integer value
+// never matches and silently disables the limit. Reject such values up front.
+function validateLimits (limits) {
+  Object.keys(limits).forEach(function (key) {
+    var value = limits[key]
+
+    if (value == null) return
+    if ((Number.isInteger(value) && value >= 0) || value === Infinity) return
+
+    throw new TypeError('Expected limits.' + key + ' to be a non-negative integer or Infinity')
+  })
+}
+
+module.exports = validateLimits

--- a/test/limits-function.js
+++ b/test/limits-function.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+var FormData = require('form-data')
+
+var multer = require('../')
+var util = require('./_util')
+
+describe('limits as a function', function () {
+  it('should call the function with the request and apply the returned limits', function (done) {
+    var seen = []
+    var upload = multer({
+      limits: function (req) {
+        seen.push(req)
+        return { fileSize: req.maxUploadSize }
+      }
+    })
+    var parser = upload.single('file')
+
+    var form1 = new FormData()
+    form1.append('file', util.file('small0.dat'))
+
+    util.submitForm(function (req, res, next) {
+      req.maxUploadSize = 100
+      parser(req, res, next)
+    }, form1, function (err, req1) {
+      assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
+
+      var form2 = new FormData()
+      form2.append('file', util.file('small0.dat'))
+
+      util.submitForm(function (req, res, next) {
+        req.maxUploadSize = Infinity
+        parser(req, res, next)
+      }, form2, function (err, req2) {
+        assert.ifError(err)
+        assert.strictEqual(req2.file.size, 1778)
+        assert.strictEqual(seen.length, 2)
+        assert.strictEqual(seen[0], req1)
+        assert.strictEqual(seen[1], req2)
+        done()
+      })
+    })
+  })
+
+  it('should treat a function returning nothing as no limits', function (done) {
+    var parser = multer({ limits: function () {} }).single('file')
+    var form = new FormData()
+
+    form.append('file', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.file.size, 1778)
+      done()
+    })
+  })
+
+  it('should pass invalid returned limits to next()', function (done) {
+    var parser = multer({ limits: function () { return { fileSize: 1.5 } } }).none()
+    var form = new FormData()
+
+    form.append('name', 'value')
+
+    util.submitForm(parser, form, function (err) {
+      assert.ok(err instanceof TypeError)
+      assert.strictEqual(err.message, 'Expected limits.fileSize to be a non-negative integer or Infinity')
+      done()
+    })
+  })
+
+  it('should pass errors thrown by the function to next()', function (done) {
+    var parser = multer({ limits: function () { throw new Error('no limits for you') } }).none()
+    var form = new FormData()
+
+    form.append('name', 'value')
+
+    util.submitForm(parser, form, function (err) {
+      assert.strictEqual(err.message, 'no limits for you')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
`limits` can now be a function that receives the request and returns the limits object, called once per request before parsing starts. The returned object is validated like a static one; errors go to `next(err)`. A static `limits` object behaves as before.

Documented in the README (limits are per request, not per file), changelog entry included.

Closes #1151