### PR TITLE
[ReadME Example] - include file extension to save it properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ const storage = multer.diskStorage({
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
-    cb(null, file.fieldname + '-' + uniqueSuffix)
+    const extension = file.originalname.slice(file.originalname.lastIndexOf("."))
+    cb(null, file.fieldname + '-' + uniqueSuffix + extension)
   }
 })
 


### PR DESCRIPTION
Example was not working: files were being saved without their extension according to the example shown for DiskStorage