### PR TITLE
Firebase function: Add check if rawBody exist in request 

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -9,12 +9,12 @@ var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
 
-function drainStream (stream) {
+function drainStream(stream) {
   stream.on('readable', stream.read.bind(stream))
 }
 
-function makeMiddleware (setup) {
-  return function multerMiddleware (req, res, next) {
+function makeMiddleware(setup) {
+  return function multerMiddleware(req, res, next) {
     if (!is(req, ['multipart'])) return next()
 
     var options = setup()
@@ -42,7 +42,7 @@ function makeMiddleware (setup) {
     var pendingWrites = new Counter()
     var uploadedFiles = []
 
-    function done (err) {
+    function done(err) {
       if (isDone) return
       isDone = true
 
@@ -53,16 +53,16 @@ function makeMiddleware (setup) {
       onFinished(req, function () { next(err) })
     }
 
-    function indicateDone () {
+    function indicateDone() {
       if (readFinished && pendingWrites.isZero() && !errorOccured) done()
     }
 
-    function abortWithError (uploadError) {
+    function abortWithError(uploadError) {
       if (errorOccured) return
       errorOccured = true
 
       pendingWrites.onceZero(function () {
-        function remove (file, cb) {
+        function remove(file, cb) {
           storage._removeFile(req, file, cb)
         }
 
@@ -75,7 +75,7 @@ function makeMiddleware (setup) {
       })
     }
 
-    function abortWithCode (code, optionalField) {
+    function abortWithCode(code, optionalField) {
       abortWithError(new MulterError(code, optionalField))
     }
 
@@ -174,7 +174,11 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
-    req.pipe(busboy)
+    if (req.rawBody) {
+      busboy.end(req.rawBody)
+    } else {
+      req.pipe(busboy);
+    }
   }
 }
 


### PR DESCRIPTION
In the latest version of Firebase Functions, the req.body is already processed by Firebase Functions, which is why Multer is not compatible anymore. However, by adding the following code, Multer will be compatible again with Firebase Functions:

`if (req.rawBody) {
` 
`    busboy.end(req.rawBody)`
`} else {`
 `   req.pipe(busboy);`
`}`
This code checks if req.rawBody exists and if it does, it ends the busboy instance with req.rawBody. If req.rawBody is not available, it pipes the req object to busboy for further processing.
