### PR TITLE
Fix file exists but file name does not exist

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -96,7 +96,15 @@ function makeMiddleware (setup) {
     // handle files
     busboy.on('file', function (fieldname, fileStream, filename, encoding, mimetype) {
       // don't attach to the files object, if there is no file
-      if (!filename) return fileStream.resume()
+      if (!filename) {
+        // @link https://github.com/mscdex/busboy/blob/master/lib/types/multipart.js
+        // If the type is 'application/octet-stream', it is also identified as a file 
+        if(mimetype==='application/octet-stream'){
+          filename = 'unknownFile'
+        }else{
+          return fileStream.resume()
+        }
+      }
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {


### PR DESCRIPTION
[https://www.rfc-editor.org/rfc/rfc1867](https://www.rfc-editor.org/rfc/rfc1867)
file name is an optional field.

eg.
```
----------------------------052948472259119770453321
Content-Disposition: form-data; name="filepond"
Content-Type: application/octet-stream
```