### PR TITLE
Fix a mistake with README-pt-br.md

### DIFF
--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -8,7 +8,7 @@ Multer é um middleware node.js para manipulação `multipart/form-data`, que é
 
 Este README também está disponível em outros idiomas:
 
-- [English](https://github.com/expressjs/multer/blob/master/doc/README-ru.md) (Inglês)
+- [English](https://github.com/expressjs/multer/blob/master/README.md) (Inglês)
 - [Español](https://github.com/expressjs/multer/blob/master/doc/README-es.md) (Espanhol)
 - [简体中文](https://github.com/expressjs/multer/blob/master/doc/README-zh-cn.md) (Chinês)
 - [한국어](https://github.com/expressjs/multer/blob/master/doc/README-ko.md) (Coreano)


### PR DESCRIPTION
Fix a issue with pt-br readme
English link was linking to russian documentation