### PR TITLE
Fixes expressjs/multer#1233. Makes multer handle missing field names.

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -87,6 +87,8 @@ function makeMiddleware (setup) {
 
     // handle files
     busboy.on('file', function (fieldname, fileStream, { filename, encoding, mimeType }) {
+      if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
+
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -175,6 +175,19 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should notify of missing field name', function (done) {
+    var form = new FormData()
+    var storage = multer.memoryStorage()
+    var parser = multer({ storage: storage }).single('small0')
+
+    form.append('', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.strictEqual(err.code, 'MISSING_FIELD_NAME')
+      done()
+    })
+  })
+
   it('should report errors from storage engines', function (done) {
     var storage = multer.memoryStorage()
 


### PR DESCRIPTION
Without this fix fields without a name result in a "TypeError: Cannot read property 'length' of undefined".

The current change allows getting an error from multer that makes it possible to handle it in servers.

See: https://github.com/expressjs/multer/issues/1233