### PR TITLE
Add final path exception

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -34,6 +34,9 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
     that.getFilename(req, file, function (err, filename) {
       if (err) return cb(err)
 
+      if(destination[destination.length -1] !== '/'){
+        destination += '/'
+      }
       var finalPath = path.join(destination, filename)
       var outStream = fs.createWriteStream(finalPath)
 

--- a/storage/disk.js
+++ b/storage/disk.js
@@ -34,7 +34,7 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
     that.getFilename(req, file, function (err, filename) {
       if (err) return cb(err)
 
-      if(destination[destination.length -1] !== '/'){
+      if(destination && destination[destination.length -1] !== '/'){
         destination += '/'
       }
       var finalPath = path.join(destination, filename)


### PR DESCRIPTION
In a random situation, I found a bug where the destination setting in diskStorage was saved as a file name by combining directory and file name with the 'join' command on line 37 of storage/disk.js. This is a patch to fix this.