### PR TITLE
Fixes expressjs/multer#1218. No response in Pending status.

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -113,18 +113,13 @@ function makeMiddleware (setup) {
       var placeholder = appender.insertPlaceholder(file)
 
       fileFilter(req, file, function (err, includeFile) {
-        if (err) {
-          appender.removePlaceholder(placeholder)
-          return abortWithError(err)
-        }
-
-        if (!includeFile) {
-          appender.removePlaceholder(placeholder)
-          return fileStream.resume()
-        }
-
         var aborting = false
         pendingWrites.increment()
+
+        if (err||!includeFile) {
+          aborting = true
+          abortWithError(err)
+        }
 
         Object.defineProperty(file, 'stream', {
           configurable: true,


### PR DESCRIPTION
When a file upload is in progress in the native app, a network communication timeout occurs in the Pending state, 

but I verified that the busboy.on('close') event does not fall into the Pending state.

I modified the code to handle errors in storage._handleFile.

See: [#1218](https://github.com/expressjs/multer/issues/1218)