### PR TITLE
fix: handle two busboy error events

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -41,7 +41,7 @@ function makeMiddleware (setup) {
       if (isDone) return
       isDone = true
       req.unpipe(busboy)
-      process.nextTick(() => {
+      setImmediate(() => {
         busboy.removeAllListeners()
       })
       next(err)

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -150,4 +150,50 @@ describe('Express Integration', function () {
     req.write(body)
     req.end()
   })
+
+  it('should not crash on malformed request that causes two errors to be emitted by busboy', function (done) {
+    var upload = multer()
+
+    app.post('/upload2', upload.single('file'), function (req, res) {
+      res.status(500).end('Request should not be processed')
+    })
+
+    app.use(function (err, req, res, next) {
+      assert.strictEqual(err.message, 'Malformed part header')
+      res.status(200).end('Correct error')
+    })
+
+    var boundary = 'AaB03x'
+    // this payload causes two errors to be emitted by busboy: `Malformed part header` and `Unexpected end of form`
+    var body = [
+      '--' + boundary,
+      'Content-Disposition: form-data; name="file"; filename="test.txt"',
+      'Content-Type: text/plain',
+      '',
+      '--' + boundary + '--',
+      ''
+    ].join('\r\n')
+    var options = {
+      hostname: 'localhost',
+      port,
+      path: '/upload2',
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=' + boundary,
+        'content-length': body.length
+      }
+    }
+
+    var req = http.request(options, (res) => {
+      assert.strictEqual(res.statusCode, 200)
+      done()
+    })
+
+    req.on('error', (err) => {
+      done(err)
+    })
+
+    req.write(body)
+    req.end()
+  })
 })


### PR DESCRIPTION
This PR enables `multer` to handle two out-of-band error events from `busboy`; it does this by replacing `process.nextTick` (which happens too soon after the first error event) with `setImmediate`.

I don't know if this fix will handle more than two, but I also don't think `busboy` will ever emit more than two.

This is a follow-up to https://github.com/expressjs/multer/pull/1177.

Resolves https://github.com/expressjs/multer/issues/1176.