### PR TITLE
📝 fix changelog information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.4.4-lts.1
 
 - Bugfix: Bump busboy to fix CVE-2022-24434 (#1097)
-- Breaking: Require Node.js 6.0.0 or later (#1097)
+- Breaking: Require Node.js 10.16.0 or later (#1097)
 
 ## 1.4.4 - 2021-12-07
 


### PR DESCRIPTION
multer 1.4.4-lts.1 upgraded busboy to 1.0.0 which [requires node 10.16.0](https://github.com/mscdex/busboy/issues/266)

this PR corrects the changelog to reflect this


<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
