### PR TITLE
Release: v3.0.0-alpha.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.0-alpha.1 - 2025-05-23
+
+- No functional changes compared to `2.0.0-rc.4`.
+- Version bump to `3.0.0-alpha.1` due to a security release in the `1.x` line, ensuring compliance with Semantic Versioning.
+
+## 2.0.0 - 2025-05-19
+
+- **Breaking change: The minimum supported Node version is now 10.16.0**
+- Fix [CVE-2025-47935](https://www.cve.org/CVERecord?id=CVE-2025-47935) ([GHSA-44fp-w29j-9vj5](https://github.com/expressjs/multer/security/advisories/GHSA-44fp-w29j-9vj5))
+- Fix [CVE-2025-47944](https://www.cve.org/CVERecord?id=CVE-2025-47944) ([GHSA-4pg4-qvpc-4q3h](https://github.com/expressjs/multer/security/advisories/GHSA-4pg4-qvpc-4q3h))
+
+## 2.0.0-rc.4 - 2022-05-27
+- Bugfix: commpatibility with Node.js < 16 
+- deps: fs-temp@^2.0.1
+
 ## 2.0.0-rc.3 - 2021-06-29
 
 - Breaking: Convert package to ESM
@@ -58,6 +73,73 @@ This relases changes the package from a Common JS module to an EcmaScript module
 
 - Feature: switch to stream based API
 - Feature: throw error when passing old options
+
+## 1.4.5-lts.2
+
+- Fix out-of-band error event from busboy (#1177)
+
+## 1.4.5-lts.1
+
+- No changes
+
+## 1.4.4-lts.1
+
+- Bugfix: Bump busboy to fix CVE-2022-24434 (#1097)
+- Breaking: Require Node.js 10.16.0 or later (#1097)
+
+## 1.4.4 - 2021-12-07
+
+- Bugfix: Handle missing field names (#913)
+- Docs: Add Vietnamese translation (#803)
+- Docs: Improve Spanish translation (#948)
+
+## 1.4.3 - 2021-08-09
+
+- Bugfix: Avoid deprecated pseudoRandomBytes function (#774)
+- Docs: Add Português Brazil translation for README (#758)
+- Docs: Clarify the callback calling convention (#775)
+- Docs: Add example on how to link to html multipart form (#580)
+- Docs: Add Spanish translation for README (#838)
+- Docs: Add Math.random() to storage filename example (#841)
+- Docs: Fix mistakes in russian doc (#869)
+- Docs: Improve Português Brazil translation (#877)
+- Docs: Update var to const in all Readmes (#1024)
+- Internal: Bump mkdirp version (#862)
+- Internal: Bump Standard version (#878)
+
+## 1.4.2 - 2019-07-16
+
+- Docs: Add Russian translation for README (#662)
+- Docs: Patch zh-CN README base on newest README (#670)
+- Docs: Fix broken link in Readme (#679)
+- Docs: Fix broken link in Chinese Readme (#730)
+- Docs: Fix typo in Russian README (#738)
+- Docs: Add unit for fieldSize in busboy limit params (#734)
+- Internal: Make unit tests comaptible with Node.js 13.x (#752)
+
+## 1.4.1 - 2018-10-11
+
+- Bugfix: Make sure that req.file.buffer always is a Buffer
+
+## 1.4.0 - 2018-09-26
+
+- Feature: Make Multer errors inherit from MulterError
+
+## 1.3.1 - 2018-06-28
+
+- Bugfix: Bump vulnerable dependency
+
+## 1.3.0 - 2017-01-25
+
+- Feature: Expose preservePath option
+
+## 1.2.1 - 2016-12-14
+
+- Bugfix: Prevent Multiple Errors from Crashing
+
+## 1.2.0 - 2016-08-04
+
+- Feature: add .none() for accepting only fields
 
 ## 1.2.0 - 2016-08-04
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.0.0-rc.4",
+  "version": "3.0.0-alpha.1",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",


### PR DESCRIPTION
### What's included in the `CHANGELOG.md`

- No functional changes compared to `2.0.0-rc.4`.
- Version bump to `3.0.0-alpha.1` due to a security release in the `1.x` line, ensuring compliance with Semantic Versioning.

## What's Changed

**Full Changelog**: https://github.com/expressjs/multer/compare/v2.0.0-rc.4...v3.0.0-alpha.1-proposal