### PR TITLE
feat: add charset option for multipart forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Key | Description
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
 `preservePath` | Keep the full path of files instead of just the base name
+`charset` | For multipart forms, the default character set to use for values of part header parameters (e.g. filename) that are not extended parameters (that contain an explicit charset). **Default**: `'latin1'`.
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ function Multer (options) {
 
   this.limits = options.limits
   this.preservePath = options.preservePath
+  // TODO: next major version change default to utf-8
+  this.charset = options.charset || 'latin1'
   this.fileFilter = options.fileFilter || allowAll
 }
 
@@ -47,6 +49,7 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
     return {
       limits: this.limits,
       preservePath: this.preservePath,
+      charset: this.charset,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
       fileStrategy: fileStrategy
@@ -77,6 +80,7 @@ Multer.prototype.any = function () {
     return {
       limits: this.limits,
       preservePath: this.preservePath,
+      charset: this.charset,
       storage: this.storage,
       fileFilter: this.fileFilter,
       fileStrategy: 'ARRAY'

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -25,6 +25,7 @@ function makeMiddleware (setup) {
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
+    var defParamCharset = options.charset
 
     req.body = Object.create(null)
 
@@ -35,7 +36,12 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      busboy = Busboy({
+        headers: req.headers,
+        limits,
+        preservePath,
+        defParamCharset
+      })
     } catch (err) {
       return next(err)
     }


### PR DESCRIPTION
Rebase of https://github.com/expressjs/multer/pull/1210, and I’m removing the changes to the READMEs since I’d prefer a native speaker to handle them. Although, I still hope to eventually remove the README translations from here.

closes #1104
closes https://github.com/expressjs/multer/pull/1210