### PR TITLE
chore(gitignore): ignore .nyc_output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ node_modules
 *.gz
 
 
-# Coveralls
+# Coverage & Test Output
 coverage
+.nyc_output


### PR DESCRIPTION
This PR updates the `.gitignore` file to exclude the `.nyc_output` directory, which is generated by the NYC code coverage tool during tests. This ensures coverage artifacts are not accidentally committed to the repository.