### PR TITLE
fix: validate all limits at construction time

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,24 @@ var diskStorage = require('./storage/disk')
 var memoryStorage = require('./storage/memory')
 var MulterError = require('./lib/multer-error')
 
+function checkLimitValue (limitKey, value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new MulterError('LIMIT_OPTION_ERROR', `option "${limitKey}" value: ${value}`)
+  }
+  return value
+}
+
+function getLimits (limitObj) {
+  if (!limitObj || typeof limitObj !== 'object' || Array.isArray(limitObj)) {
+    throw new TypeError('Expected limits to be a plain object')
+  }
+  var limits = {}
+  Object.keys(limitObj).forEach(key => {
+    limits[key] = checkLimitValue(key, limitObj[key])
+  })
+  return limits
+}
+
 function allowAll (req, file, cb) {
   cb(null, true)
 }
@@ -17,7 +35,7 @@ function Multer (options) {
     this.storage = memoryStorage()
   }
 
-  this.limits = options.limits
+  this.limits = options.limits ? getLimits(options.limits) : options.limits
   this.preservePath = options.preservePath
   this.fileFilter = options.fileFilter || allowAll
 }
@@ -91,7 +109,7 @@ function multer (options) {
     return new Multer({})
   }
 
-  if (typeof options === 'object' && options !== null) {
+  if (typeof options === 'object' && options !== null && !Array.isArray(options)) {
     return new Multer(options)
   }
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,19 @@ function allowAll (req, file, cb) {
   cb(null, true)
 }
 
+// busboy compares most limits with strict equality, so a non-integer value
+// never matches and silently disables the limit. Reject such values up front.
+function validateLimits (limits) {
+  Object.keys(limits).forEach(function (key) {
+    var value = limits[key]
+
+    if (value == null) return
+    if ((Number.isInteger(value) && value >= 0) || value === Infinity) return
+
+    throw new TypeError('Expected limits.' + key + ' to be a non-negative integer or Infinity')
+  })
+}
+
 function Multer (options) {
   if (options.storage) {
     this.storage = options.storage
@@ -17,10 +30,7 @@ function Multer (options) {
     this.storage = memoryStorage()
   }
 
-  if (options.limits && options.limits.fileSize != null &&
-    !Number.isInteger(options.limits.fileSize) && options.limits.fileSize !== Infinity) {
-    throw new TypeError('Expected limits.fileSize to be an integer or Infinity')
-  }
+  if (options.limits) validateLimits(options.limits)
 
   this.limits = options.limits
   this.preservePath = options.preservePath

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -8,7 +8,8 @@ var errorMessages = {
   LIMIT_FIELD_VALUE: 'Field value too long',
   LIMIT_FIELD_COUNT: 'Too many fields',
   LIMIT_UNEXPECTED_FILE: 'Unexpected field',
-  MISSING_FIELD_NAME: 'Field name missing'
+  MISSING_FIELD_NAME: 'Field name missing',
+  LIMIT_OPTION_ERROR: 'Limit option must be an integer'
 }
 
 function MulterError (code, field) {
@@ -16,7 +17,10 @@ function MulterError (code, field) {
   this.name = this.constructor.name
   this.message = errorMessages[code]
   this.code = code
-  if (field) this.field = field
+  if (field) {
+    this.field = field
+    if (code === 'LIMIT_OPTION_ERROR') this.message += `: ${field}`
+  }
 }
 
 util.inherits(MulterError, Error)

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -14,6 +14,60 @@ function withLimits (limits, fields) {
 }
 
 describe('Error Handling', function () {
+  const invalidPlainObj = ['not an plain object', ['storage', 'limits']]
+
+  const invalidLimitOptions = [
+    { option: 'fieldNameSize', value: -100 },
+    { option: 'fieldSize', value: 0.5 },
+    { option: 'fields', value: '10' },
+    { option: 'files', value: 'foo' },
+    { option: 'fileSize', value: 1048.15 },
+    { option: 'parts', value: '0' },
+    { option: 'headersPairs', value: -10.55 }
+  ]
+
+  invalidLimitOptions.forEach(({ option, value }) => {
+    it(`should throw an invalid limit option error for ${option} with value ${value}`, () => {
+      assert.throws(
+        () => multer({ limits: { [option]: value } }),
+        (err) => {
+          return (
+            err instanceof multer.MulterError &&
+              err.name === 'MulterError' &&
+              err.code === 'LIMIT_OPTION_ERROR' &&
+              err.field === `option "${option}" value: ${value}` &&
+              err.message === `Limit option must be an integer: option "${option}" value: ${value}`
+          )
+        },
+          `Expected multer to reject ${option} value for ${value}`
+      )
+    })
+  })
+
+  it('should throw argument type error if limits is not a plain object', function () {
+    invalidPlainObj.forEach(option=>{
+      assert.throws(
+        () => multer({ limits: option }),
+        (err) => {
+          return err instanceof TypeError && err.message === 'Expected limits to be a plain object'
+        },
+        'Expected multer to throw TypeError for non-object limits'
+      )
+    })
+  })
+
+  it('should throw type error if options is not a plain object', function () {
+    invalidPlainObj.forEach(option=>{
+      assert.throws(
+        () => multer(option),
+        (err) => {
+          return err instanceof TypeError && err.message === 'Expected object for argument options'
+        },
+        'Expected multer to throw TypeError for non plain object options'
+      )
+    })
+  })
+
   it('should be an instance of both `Error` and `MulterError` classes in case of the Multer\'s error', function (done) {
     var form = new FormData()
     var storage = multer.diskStorage({ destination: os.tmpdir() })

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -45,7 +45,7 @@ describe('Error Handling', function () {
   })
 
   it('should throw argument type error if limits is not a plain object', function () {
-    invalidPlainObj.forEach(option=>{
+    invalidPlainObj.forEach(option => {
       assert.throws(
         () => multer({ limits: option }),
         (err) => {
@@ -57,7 +57,7 @@ describe('Error Handling', function () {
   })
 
   it('should throw type error if options is not a plain object', function () {
-    invalidPlainObj.forEach(option=>{
+    invalidPlainObj.forEach(option => {
       assert.throws(
         () => multer(option),
         (err) => {

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -561,26 +561,35 @@ describe('Error Handling', function () {
     })
   })
 
-  it('should throw TypeError when fileSize limit is not an integer', function () {
-    // busboy only emits 'limit' when the byte count equals the limit exactly,
-    // so a float limit silently truncates the file instead of rejecting it
+  it('should throw TypeError when a limit is not a non-negative integer', function () {
+    // busboy compares limits with strict equality, so a float limit would
+    // never trigger and silently disable the check
     assert.throws(function () {
       multer({ limits: { fileSize: 1024.5 } })
     }, {
       name: 'TypeError',
-      message: 'Expected limits.fileSize to be an integer or Infinity'
+      message: 'Expected limits.fileSize to be a non-negative integer or Infinity'
     })
 
     assert.throws(function () {
-      multer({ limits: { fileSize: '1024' } })
-    }, TypeError)
+      multer({ limits: { parts: 2.5 } })
+    }, /Expected limits\.parts/)
+
+    assert.throws(function () {
+      multer({ limits: { files: -1 } })
+    }, /Expected limits\.files/)
+
+    assert.throws(function () {
+      multer({ limits: { fields: '3' } })
+    }, /Expected limits\.fields/)
   })
 
-  it('should accept an integer or Infinity fileSize limit', function () {
+  it('should accept integer, Infinity and unset limits', function () {
     assert.doesNotThrow(function () {
-      multer({ limits: { fileSize: 1024 } })
+      multer({ limits: { fileSize: 1024, files: 2, fields: 0, parts: Infinity, fileSize2: null } })
       multer({ limits: { fileSize: Infinity } })
       multer({ limits: {} })
+      multer({})
     })
   })
 


### PR DESCRIPTION
busboy compares most limits (`files`, `fields`, `parts`, `fileSize`, `fieldSize`) with strict equality, so a non-integer value never matches and silently disables that limit. #1395 fixed this for `fileSize`; this extends the same check to every key in `limits`: each must be a non-negative integer or `Infinity` (the documented default), otherwise `multer()` throws a `TypeError`. No new error code; config errors stay `TypeError`s like the existing `options` check.

Rebased onto `main` as a single commit with the original approach simplified (no `MulterError` for construction-time errors, `Infinity` accepted).