### PR TITLE
deps: update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "concat-stream": "^2.0.0",
     "mkdirp": "^0.5.6",
     "object-assign": "^4.1.1",
-    "type-is": "^1.6.18",
+    "type-is": "^2.0.1",
     "xtend": "^4.0.2"
   },
   "devDependencies": {
     "deep-equal": "^2.0.3",
-    "express": "^4.21.2",
+    "express": "^5.1.0",
     "form-data": "^4.0.2",
     "fs-temp": "^1.2.1",
     "mocha": "^11.5.0",


### PR DESCRIPTION
-  Update the version of  `type-is`

multer@2.0.1
`-- type-is@1.6.18
  `-- @0.3.0

In this `makeMiddleware ` function, we used the `media-typer` module  provided by `type-is`.
However, the lower versions of `media-typer` do not have the `test` method

Version 0.3.0 of `media-typer ` does not provide the ` test` method, which will result in an error in the production environment，


- Update the version of  `express`

Avoid the impact of `type-is` version desynchronization

