### PR TITLE
chore: drop object-assign dependency

### DIFF
--- a/lib/file-appender.js
+++ b/lib/file-appender.js
@@ -1,5 +1,3 @@
-var objectAssign = require('object-assign')
-
 function arrayRemove (arr, item) {
   var idx = arr.indexOf(item)
   if (~idx) arr.splice(idx, 1)
@@ -61,7 +59,7 @@ FileAppender.prototype.replacePlaceholder = function (placeholder, file) {
   }
 
   delete placeholder.fieldname
-  objectAssign(placeholder, file)
+  Object.assign(placeholder, file)
 }
 
 module.exports = FileAppender

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "append-field": "^1.0.0",
     "busboy": "^1.6.0",
     "concat-stream": "^2.0.0",
-    "object-assign": "^4.1.1",
     "type-is": "^1.6.18",
     "xtend": "^4.0.2"
   },


### PR DESCRIPTION
`Object.assign` is natively supported since Node.js v4.0.0. Minimum version of Node.js supported by multer at the moment is v10.16.0, so we should be good to go.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
