### PR TITLE
chore: drop xtend dependency

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -1,6 +1,5 @@
 var is = require('type-is')
 var Busboy = require('busboy')
-var extend = require('xtend')
 var appendField = require('append-field')
 
 var Counter = require('./counter')
@@ -158,7 +157,7 @@ function makeMiddleware (setup) {
         storage._handleFile(req, file, function (err, info) {
           if (aborting) {
             appender.removePlaceholder(placeholder)
-            uploadedFiles.push(extend(file, info))
+            uploadedFiles.push({ ...file, ...info })
             return pendingWrites.decrement()
           }
 
@@ -168,7 +167,7 @@ function makeMiddleware (setup) {
             return abortWithError(err)
           }
 
-          var fileInfo = extend(file, info)
+          var fileInfo = { ...file, ...info }
 
           appender.replacePlaceholder(placeholder, fileInfo)
           uploadedFiles.push(fileInfo)

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "append-field": "^1.0.0",
     "busboy": "^1.6.0",
     "concat-stream": "^2.0.0",
-    "type-is": "^1.6.18",
-    "xtend": "^4.0.2"
+    "type-is": "^1.6.18"
   },
   "devDependencies": {
     "deep-equal": "^2.0.3",


### PR DESCRIPTION
Spread in object literals is natively supported in Node.js since v8.3.0. Minimum version of Node.js supported by multer at the moment is v10.16.0, so we should be good to go.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
