### PR TITLE
refactor: remove concat-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "dependencies": {
     "append-field": "^1.0.0",
     "busboy": "^1.6.0",
-    "concat-stream": "^2.0.0",
     "type-is": "^1.6.18"
   },
   "devDependencies": {
+    "concat-stream": "^2.0.0",
     "deep-equal": "^2.0.3",
     "express": "^4.21.2",
     "form-data": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "append-field": "^1.0.0",
     "busboy": "^1.6.0",
-    "concat-stream": "^2.0.0",
     "type-is": "^1.6.18"
   },
   "devDependencies": {

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -1,21 +1,91 @@
-var concat = require('concat-stream')
+const Writable = require('stream').Writable
+const Buffer = require('buffer').Buffer
+const isUint8Array = require('util').types.isUint8Array
 
-function MemoryStorage (opts) {}
+class MemoryStorage {
+  _handleFile (req, file, cb) {
+    file.stream.pipe(
+      new ConcatStream(function (data) {
+        cb(null, {
+          buffer: data,
+          size: data.length
+        })
+      })
+    )
+  }
 
-MemoryStorage.prototype._handleFile = function _handleFile (req, file, cb) {
-  file.stream.pipe(concat({ encoding: 'buffer' }, function (data) {
-    cb(null, {
-      buffer: data,
-      size: data.length
+  _removeFile (req, file, cb) {
+    delete file.buffer
+    cb(null)
+  }
+}
+
+module.exports = function () {
+  return new MemoryStorage()
+}
+
+/**
+ * Writable stream that concatenates all written chunks into a single Buffer.
+ *
+ * Implementation inspired by the concat-stream npm package (https://www.npmjs.com/package/concat-stream),
+ * modified for our specific use case.
+ */
+class ConcatStream extends Writable {
+  /**
+   * Creates a new ConcatStream instance.
+   * @param {function(Buffer): void} cb - Callback invoked with the concatenated Buffer when the stream finishes.
+   */
+  constructor (cb) {
+    super()
+    this.body = []
+    this.on('finish', function () {
+      cb(this.getBody())
     })
-  }))
+  }
+
+  _write (chunk, enc, next) {
+    this.body.push(chunk)
+    next()
+  }
+
+  /**
+   * Concatenates all collected chunks into a single Buffer.
+   * @returns {Buffer} The concatenated buffer containing all written data.
+   */
+  getBody () {
+    const bufs = []
+    for (const p of this.body) {
+      // Buffer.concat can handle Buffer and Uint8Array (and subclasses)
+      if (Buffer.isBuffer(p) || isUint8Array(p)) {
+        bufs.push(p)
+      } else if (isBufferish(p)) {
+        bufs.push(Buffer.from(p))
+      } else {
+        bufs.push(Buffer.from(String(p)))
+      }
+    }
+    return Buffer.concat(bufs)
+  }
 }
 
-MemoryStorage.prototype._removeFile = function _removeFile (req, file, cb) {
-  delete file.buffer
-  cb(null)
+/**
+ * Checks if the given value is array-like.
+ * @param {*} arr
+ * @returns {boolean}
+ */
+function isArrayish (arr) {
+  return /Array\]$/.test(Object.prototype.toString.call(arr))
 }
 
-module.exports = function (opts) {
-  return new MemoryStorage(opts)
+/**
+ * Checks if the given value is Buffer-like.
+ * @param {*} p
+ * @returns {boolean}
+ */
+function isBufferish (p) {
+  return (
+    typeof p === 'string' ||
+    isArrayish(p) ||
+    (p && typeof p.subarray === 'function')
+  )
 }

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -1,14 +1,20 @@
-var concat = require('concat-stream')
-
 function MemoryStorage (opts) {}
 
 MemoryStorage.prototype._handleFile = function _handleFile (req, file, cb) {
-  file.stream.pipe(concat({ encoding: 'buffer' }, function (data) {
+  var chunks = []
+
+  file.stream.on('data', function (chunk) {
+    chunks.push(chunk)
+  })
+
+  file.stream.on('end', function () {
+    var buffer = Buffer.concat(chunks)
+
     cb(null, {
-      buffer: data,
-      size: data.length
+      buffer: buffer,
+      size: buffer.length
     })
-  }))
+  })
 }
 
 MemoryStorage.prototype._removeFile = function _removeFile (req, file, cb) {

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -8,7 +8,6 @@ var util = require('./_util')
 
 var express = require('express')
 var FormData = require('form-data')
-var concat = require('concat-stream')
 
 var port = 34279
 
@@ -25,10 +24,11 @@ describe('Express Integration', function () {
 
     req.on('error', cb)
     req.on('response', function (res) {
+      var chunks = []
+
       res.on('error', cb)
-      res.pipe(concat({ encoding: 'buffer' }, function (body) {
-        cb(null, res, body)
-      }))
+      res.on('data', function (chunk) { chunks.push(chunk) })
+      res.on('end', function () { cb(null, res, Buffer.concat(chunks)) })
     })
   }
 


### PR DESCRIPTION
Removes `concat-stream` from the dependencies. busboy file streams only emit Buffers, so `MemoryStorage` collects the chunks and `Buffer.concat`s them itself; the one test that used it does the same. This drops `concat-stream` and its transitive dependencies (`readable-stream`, `buffer-from`, `typedarray`, `inherits`) from the production install.

Rebased onto `main` as a single commit with the minimal implementation (no generic buffer coercion, prototype style like the rest of `storage/`).