### PR TITLE
refactor: modernize MulterError to ES6 class

### DIFF
--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -1,6 +1,4 @@
-var util = require('util')
-
-var errorMessages = {
+const errorMessages = {
   LIMIT_PART_COUNT: 'Too many parts',
   LIMIT_FILE_SIZE: 'File too large',
   LIMIT_FILE_COUNT: 'Too many files',
@@ -11,14 +9,13 @@ var errorMessages = {
   MISSING_FIELD_NAME: 'Field name missing'
 }
 
-function MulterError (code, field) {
-  Error.captureStackTrace(this, this.constructor)
-  this.name = this.constructor.name
-  this.message = errorMessages[code]
-  this.code = code
-  if (field) this.field = field
+class MulterError extends Error {
+  constructor (code, field) {
+    super(errorMessages[code])
+    this.name = this.constructor.name
+    this.code = code
+    if (field) this.field = field
+  }
 }
-
-util.inherits(MulterError, Error)
 
 module.exports = MulterError


### PR DESCRIPTION
This PR modernizes the MulterError implementation by converting it from a function constructor with the legacy util.inherits() pattern to an ES6 class.