### PR TITLE
Bind AsyncResource on busboy close event to preserve async context

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -6,6 +6,7 @@ var Counter = require('./counter')
 var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
+var { AsyncResource } = require('async_hooks')
 
 function drainStream (stream) {
   stream.on('readable', () => {
@@ -181,13 +182,20 @@ function makeMiddleware (setup) {
     busboy.on('partsLimit', function () { abortWithCode('LIMIT_PART_COUNT') })
     busboy.on('filesLimit', function () { abortWithCode('LIMIT_FILE_COUNT') })
     busboy.on('fieldsLimit', function () { abortWithCode('LIMIT_FIELD_COUNT') })
-    busboy.on('close', function () {
+    busboy.on('close', bindToAsyncResource(function () {
       readFinished = true
       indicateDone()
-    })
+    }))
 
     req.pipe(busboy)
   }
+}
+function bindToAsyncResource(fn) {
+  if (typeof AsyncResource?.bind === "function") {
+    return AsyncResource.bind(fn);
+  }
+
+  return fn;
 }
 
 module.exports = makeMiddleware

--- a/test/async-context.js
+++ b/test/async-context.js
@@ -1,0 +1,66 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+var express = require('express')
+var FormData = require('form-data')
+var concat = require('concat-stream')
+var multer = require('..')
+
+var asyncHooks = require('async_hooks')
+
+var port = 34280
+
+describe('Async context preservation', function () {
+  var app
+
+  before(function (done) {
+    app = express()
+    app.listen(port, done)
+  })
+
+  function submitForm (form, path, cb) {
+    var req = form.submit('http://localhost:' + port + path)
+
+    req.on('error', cb)
+    req.on('response', function (res) {
+      res.on('error', cb)
+      res.pipe(concat({ encoding: 'buffer' }, function (body) {
+        cb(null, res, body)
+      }))
+    })
+  }
+
+  it('should preserve AsyncLocalStorage context across multer processing', function (done) {
+    if (!asyncHooks || typeof asyncHooks.AsyncResource !== 'function' || typeof asyncHooks.AsyncResource.bind !== 'function') {
+      this.skip()
+    }
+
+    if (typeof asyncHooks.AsyncLocalStorage !== 'function') {
+      this.skip()
+    }
+
+    var AsyncLocalStorage = asyncHooks.AsyncLocalStorage
+    var als = new AsyncLocalStorage()
+
+    var upload = multer()
+    var form = new FormData()
+
+    form.append('field', 'value')
+
+    app.post('/ctx', function (req, res, next) {
+      als.run({ requestId: 'abc-123' }, function () { next() })
+    }, upload.none(), function (req, res) {
+      var store = als.getStore()
+      var requestId = store && store.requestId
+      res.status(200).end(requestId || 'NO_CONTEXT')
+    })
+
+    submitForm(form, '/ctx', function (err, res, body) {
+      assert.ifError(err)
+      assert.strictEqual(res.statusCode, 200)
+      assert.strictEqual(body.toString(), 'abc-123')
+      done()
+    })
+  })
+})
+


### PR DESCRIPTION
When using `multer` the [Async Local Storage](https://nodejs.org/api/async_context.htm) gets lost. This is because the busboys event handler runs next and after event handlers the async context gets lost in Node.js.

This was reported in #814 and #1111

I added a feature detect `AsyncStroage.bind` to make sure the context is not lost.

I tested this based on the the [multer-test](https://github.com/C-Saunders/multer-test) repository by @C-saunders and it worked 👏 

Let me know what you think!