### PR TITLE
  Fix file size validation issue in multer# 1348

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -34,7 +34,12 @@ function makeMiddleware (setup) {
     var busboy
 
     try {
-      busboy = Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
+      // Adjust limits.fileSize by +1 to prevent Busboy from emitting 'limit' for files exactly at the limit
+      var adjustedLimits = { ...limits }
+      if (adjustedLimits.fileSize != null) {
+        adjustedLimits.fileSize += 1
+      }
+      busboy = Busboy({ headers: req.headers, limits: adjustedLimits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }


### PR DESCRIPTION
### Summary
Fixes an off-by-one issue where Multer throws a "File too large" error
when the uploaded file size is exactly equal to `limits.fileSize`.

### Root Cause
Busboy emits a `limit` event when the file size equals the limit.
Multer interpreted this as an overflow, rejecting valid uploads.

### Fix
Adjusted the limit logic by incrementing `limits.fileSize` by 1 before
passing to Busboy. This ensures only files exceeding the limit are rejected.

### Testing
✅ Uploaded files with size exactly equal to `limits.fileSize` → success  
✅ Uploaded files exceeding the limit → correctly rejected
