### PR TITLE
docs: clarify CommonJS usage for Multer v2 ESM export

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,21 @@ Don't forget the `enctype="multipart/form-data"` in your form.
   <input type="file" name="avatar" />
 </form>
 ```
+### CommonJS and ES Module interoperability
+
+Multer v2 is published as an ES module.
+
+When using Multer v2 from CommonJS (`require`), `require("multer")`
+returns a module namespace object rather than the middleware function.
+
+Use the default export explicitly:
 
 ```javascript
-const express = require('express')
-const multer  = require('multer')
-const upload = multer({ dest: 'uploads/' })
+const express = require("express");
+const multer = require("multer").default;
+
+const upload = multer({ dest: "uploads/" });
+
 
 const app = express()
 


### PR DESCRIPTION
Multer v2 is published as an ES module. When used from CommonJS,
require("multer") returns a module namespace object, which causes
TypeError: multer is not a function.

This PR updates the README to clarify how to access the default
export or use ES module syntax.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
