### PR TITLE
doc: adds context for link to Chinese README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This README is also available in other languages:
 |                                                                                |                 |
 | ------------------------------------------------------------------------------ | --------------- |
 | [العربية](https://github.com/expressjs/multer/blob/main/doc/README-ar.md)      | Arabic          |
-| [简体中文](https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md)  | Chinese         |
+| [简体中文](https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md)  | Chinese (Simplified)         |
 | [Français](https://github.com/expressjs/multer/blob/main/doc/README-fr.md)     | French          |
 | [한국어](https://github.com/expressjs/multer/blob/main/doc/README-ko.md)       | Korean          |
 | [Português](https://github.com/expressjs/multer/blob/main/doc/README-pt-br.md) | Portuguese (BR) |


### PR DESCRIPTION
follows convention to distinguish between Simplified (vs. Traditional) Chinese