### PR TITLE
Release: 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.0
+
+- Add `defParamCharset` option for UTF-8 filename support ([#1210](https://github.com/expressjs/multer/pull/1210))
+- Fix [CVE-2026-2359](https://www.cve.org/CVERecord?id=CVE-2026-2359) ([GHSA-v52c-386h-88mc](https://github.com/expressjs/multer/security/advisories/GHSA-v52c-386h-88mc))
+- Fix [CVE-2026-3304](https://www.cve.org/CVERecord?id=CVE-2026-3304) ([GHSA-xf7r-hgr6-v32p](https://github.com/expressjs/multer/security/advisories/GHSA-xf7r-hgr6-v32p))
+
+
 ## 2.0.2
 
 - Fix [CVE-2025-7338](https://www.cve.org/CVERecord?id=CVE-2025-7338) ([GHSA-fjgf-rc76-4x9p](https://github.com/expressjs/multer/security/advisories/GHSA-fjgf-rc76-4x9p))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",


### PR DESCRIPTION
### What's included in the `CHANGELOG.md`

```
## 2.1.0

- Add `defParamCharset` option for UTF-8 filename support ([#1210](https://github.com/expressjs/multer/pull/1210))
- Fix [CVE-2026-2359](https://www.cve.org/CVERecord?id=CVE-2026-2359) ([GHSA-v52c-386h-88mc](https://github.com/expressjs/multer/security/advisories/GHSA-v52c-386h-88mc))
- Fix [CVE-2026-3304](https://www.cve.org/CVERecord?id=CVE-2026-3304) ([GHSA-xf7r-hgr6-v32p](https://github.com/expressjs/multer/security/advisories/GHSA-xf7r-hgr6-v32p))
```


## What's Changed
* chore: add funding to package.json by @bjohansebas in https://github.com/expressjs/multer/pull/1346
* chore: drop mkdirp dependency by @wojtekmaj in https://github.com/expressjs/multer/pull/1350
* chore: drop object-assign dependency by @wojtekmaj in https://github.com/expressjs/multer/pull/1351
* chore: drop xtend dependency by @wojtekmaj in https://github.com/expressjs/multer/pull/1352
* chore(gitignore): ignore .nyc_output directory by @ShubhamOulkar in https://github.com/expressjs/multer/pull/1332
* Fix typo in README-vi.md regarding file upload by @Kunniii in https://github.com/expressjs/multer/pull/1366
* Fix typo in README-pt-br.md for array method by @matheushbm192 in https://github.com/expressjs/multer/pull/1367
* headers-support-utf8 by @Doc999tor in https://github.com/expressjs/multer/pull/1210
* Add Turkish translation (README-tr.md) by @Sabandogan in https://github.com/expressjs/multer/pull/1360

## New Contributors
* @wojtekmaj made their first contribution in https://github.com/expressjs/multer/pull/1350
* @ShubhamOulkar made their first contribution in https://github.com/expressjs/multer/pull/1332
* @Kunniii made their first contribution in https://github.com/expressjs/multer/pull/1366
* @matheushbm192 made their first contribution in https://github.com/expressjs/multer/pull/1367
* @Doc999tor made their first contribution in https://github.com/expressjs/multer/pull/1210
* @Sabandogan made their first contribution in https://github.com/expressjs/multer/pull/1360

**Full Changelog**: https://github.com/expressjs/multer/compare/v2.0.2...main