### PR TITLE
2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 2.1.1
 
 - Fix [CVE-2026-3520](https://www.cve.org/CVERecord?id=CVE-2026-3520) ([GHSA-5528-5vmv-3xc2](https://github.com/expressjs/multer/security/advisories/GHSA-5528-5vmv-3xc2))
-
+- fix error/abort handling
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.1
+
+- Fix [CVE-2026-3520](https://www.cve.org/CVERecord?id=CVE-2026-3520) ([GHSA-5528-5vmv-3xc2](https://github.com/expressjs/multer/security/advisories/GHSA-5528-5vmv-3xc2))
+
+
 ## 2.1.0
 
 - Add `defParamCharset` option for UTF-8 filename support ([#1210](https://github.com/expressjs/multer/pull/1210))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",


### PR DESCRIPTION
### What's included in the `CHANGELOG.md`

```
## 2.1.1

- Fix [CVE-2026-3520](https://www.cve.org/CVERecord?id=CVE-2026-3520) ([GHSA-5528-5vmv-3xc2](https://github.com/expressjs/multer/security/advisories/GHSA-5528-5vmv-3xc2))
```

## What's Changed
* chore: add node version to 25.x in CI by @imangas in https://github.com/expressjs/multer/pull/1372
* chore(deps): bump ossf/scorecard-action from 2.4.0 to 2.4.3 by @dependabot[bot] in https://github.com/expressjs/multer/pull/1378
* chore(deps): bump coverallsapp/github-action from 1.2.5 to 2.3.6 by @dependabot[bot] in https://github.com/expressjs/multer/pull/1377
* chore(deps): bump github/codeql-action from 3.24.7 to 4.32.4 by @dependabot[bot] in https://github.com/expressjs/multer/pull/1376
* chore(deps): bump actions/upload-artifact from 4.5.0 to 7.0.0 by @dependabot[bot] in https://github.com/expressjs/multer/pull/1375
* chore(deps): bump actions/checkout from 4.1.1 to 6.0.2 by @dependabot[bot] in https://github.com/expressjs/multer/pull/1374
* fix error/abort handling by @ctcpip in https://github.com/expressjs/multer/pull/1373

## New Contributors
* @imangas made their first contribution in https://github.com/expressjs/multer/pull/1372
* @dependabot[bot] made their first contribution in https://github.com/expressjs/multer/pull/1378

**Full Changelog**: https://github.com/expressjs/multer/compare/v2.1.0...main