### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Docs: Fix broken link in Chinese Readme (#730)
 - Docs: Fix typo in Russian README (#738)
 - Docs: Add unit for fieldSize in busboy limit params (#734)
-- Internal: Make unit tests comaptible with Node.js 13.x (#752)
+- Internal: Make unit tests compatible with Node.js 13.x (#752)
 
 ## 1.4.1 - 2018-10-11
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This README is also available in other languages:
 | [Русский язык](https://github.com/expressjs/multer/blob/main/doc/README-ru.md) | Russian         |
 | [Español](https://github.com/expressjs/multer/blob/main/doc/README-es.md)      | Spanish         |
 | [O'zbek tili](https://github.com/expressjs/multer/blob/main/doc/README-uz.md)  | Uzbek           |
-| [Việt Nam](https://github.com/expressjs/multer/blob/main/doc/README-vi.md)     | Vietnamese      |
+| [Việt Name](https://github.com/expressjs/multer/blob/main/doc/README-vi.md)     | Vietnamese      |
 | [Türkçe](https://github.com/expressjs/multer/blob/main/doc/README-tr.md)       | Turkish         |
 
 

--- a/doc/README-ar.md
+++ b/doc/README-ar.md
@@ -16,7 +16,7 @@
 - [简体中文](https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md) (الصينية)
 - [한국어](https://github.com/expressjs/multer/blob/main/doc/README-ko.md) (الكورية)
 - [Русский язык](https://github.com/expressjs/multer/blob/main/doc/README-ru.md) (الروسية)
-- [Việt Nam](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (الفتنامية)
+- [Việt Name](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (الفتنامية)
 - [Português](https://github.com/expressjs/multer/blob/main/doc/README-pt-br.md) (البرتغالية)
 
 

--- a/doc/README-es.md
+++ b/doc/README-es.md
@@ -77,7 +77,7 @@ app.post('/profile', upload.none(), function (req, res, next) {
 ```
 
 
-Este es un ejemplo de cómo se utiliza multer en un formulario HTML. Presta especial atención en los campos `enctype="multipart/form-data"` y `name="uploaded_file"`:
+Este es un ejemplo de cómo se utilize multer en un formulario HTML. Presta especial atención en los campos `enctype="multipart/form-data"` y `name="uploaded_file"`:
 
 ```html
 <form action="/stats" enctype="multipart/form-data" method="post">
@@ -125,9 +125,9 @@ Clave (Key) | Descripción | Nota
 
 Multer acepta un objeto para configurar sus opciones, la más básica de ellas es la propiedad `dest`, la cual informa a Multer dónde debe subir los archivos. En caso de que omitas el objeto con las opciones, los archivos serán guardados en la memoria y nunca serán escritos en el disco.
 
-Por defecto, Multer renombrará los archivos para evitar conflictos de nombres. La función usada para renombrarlos puede ser modificada acorde a tus necesidades.
+Por defecto, Multer renombrará los archivos para evitar conflictos de nombres. La función usada para renombrarlos puede set modificada acorde a tus necesidades.
 
-Las siguientes son las opciones que pueden ser utilizadas con Multer.
+Las siguientes son las opciones que pueden set utilizadas con Multer.
 
 Clave (key) | Descripción
 --- | ---
@@ -135,7 +135,7 @@ Clave (key) | Descripción
 `fileFilter` | Función para controlar qué archivos son aceptados
 `limits` | Límites de los datos subidos
 `preservePath` | Mantiene la ruta completa de la ubicación de los archivos, en vez de sólo sus nombres
-`defParamCharset` | Conjunto de caracteres por defecto para usar en valores de parámetros de encabezados de partes (ej. nombre de archivo) que no son parámetros extendidos (que contienen un conjunto de caracteres explícito). Por defecto: `'latin1'`
+`defParamCharset` | Conjunto de characters por defecto para usar en valores de parámetros de encabezados de partes (ej. nombre de archivo) que no son parámetros extendidos (que contienen un conjunto de characters explícito). Por defecto: `'latin1'`
 
 En la aplicación web promedio es probable que sólo se requiera `dest`, siendo configurado como en el siguiente ejemplo:
 
@@ -157,7 +157,7 @@ Acepta un arreglo (array), de archivos, todos con el nombre `fieldname`. Opciona
 
 Acepta una mezcla de archivos, especificados por `field`. Un objeto con arreglos (arrays) de archivos será guardado en `req.files`
 
-`fields` debería ser un arreglo (array) de objetos con `name` y opcionalmente `maxCount`.
+`fields` debería set un arreglo (array) de objetos con `name` y opcionalmente `maxCount`.
 Ejemplo:
 
 ```javascript
@@ -199,11 +199,11 @@ const upload = multer({ storage: storage })
 
 Hay dos opciones disponibles, `destination` y `filename`. Ambas son funciones que determinan dónde debería almacenarse el archivo.
 
-`destination` se utiliza para determinar en qué carpeta se almacenarán los archivos subidos. Tambien se puede proporcionar como un `string` (por ejemplo: `'/tmp/uploads'`). Si no se proporciona `destination`, se utilizara el directorio predeterminado del sistema operativo para archivos temporales.
+`destination` se utilize para determinar en qué carpeta se almacenarán los archivos subidos. Tambien se puede proporcionar como un `string` (por ejemplo: `'/tmp/uploads'`). Si no se proporciona `destination`, se utilizara el directorio predeterminado del sistema operativo para archivos temporales.
 
-**Nota:** Al pasar `destination` como una función, tú eres el responsable de crear los directorios donde los archivos serán almacenados. Cuando asignas un `string` a `destination`, Multer se asegurará de que el directorio sea creado en caso de no encontrarlo.
+**Nota:** Al pasar `destination` como una función, tú eres el responsible de crear los directorios donde los archivos serán almacenados. Cuando asignas un `string` a `destination`, Multer se asegurará de que el directorio sea creado en caso de no encontrarlo.
 
-`filename` es usado para determinar cómo debería ser nombrado el archivo dentro de la carpeta. Si `filename` no es provisto, a cada archivo se le asignará un nombre aleatorio que no incluirá ninguna extensión.
+`filename` es usado para determinar cómo debería set nombrado el archivo dentro de la carpeta. Si `filename` no es provisto, a cada archivo se le asignará un nombre aleatorio que no incluirá ninguna extensión.
 
 **Nota:** Multer no añadirá ningúna extensión de archivos por ti, es tu función la que debería retornar un nombre completo, que incluya también la extensión del archivo.
 
@@ -241,19 +241,19 @@ Clave (Key) | Descripción | Por defecto
 `fileSize` | Para formularios multiparte, el tamaño máximo de los archivos (en bytes) | Infinito
 `files` | Para los formularios multiparte, el número máximo de campos para archivos | Infinito
 `parts` | Para los formularios multiparte, el número máximo de partes (campos + archivos) | Infinito
-`headerPairs` | Para los formularios multiparte, el número máximo de cabeceras de pares clave=>valor para analizar | 2000
+`headerPairs` | Para los formularios multiparte, el número máximo de cabeceras de pairs clave=>valor para analizar | 2000
 
 Especificar los límites puede ayudarte a proteger tu sitio contra ataques de denegación del servicio (DoS).
 
 ### `fileFilter`
 
-Asigna ésto a una función para controlar cuáles archivos deben ser subidos y cuáles deben ser omitidos. La función debería verse como ésta:
+Asigna ésto a una función para controlar cuáles archivos deben set subidos y cuáles deben set omitidos. La función debería verse como ésta:
 
 ```javascript
 function fileFilter (req, file, cb) {
 
   // La función debe llamar a `cb` usando una variable del tipo boolean
-  // para indicar si el archivo debería ser aceptado o no
+  // para indicar si el archivo debería set aceptado o no
 
   // Para rechazar el archivo es necesario pasar `false`, de la siguiente forma:
   cb(null, false)

--- a/doc/README-fr.md
+++ b/doc/README-fr.md
@@ -14,7 +14,7 @@ This README is also available in other languages:
 - [简体中文](https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md) (Chinois)
 - [한국어](https://github.com/expressjs/multer/blob/main/doc/README-ko.md) (Coréen)
 - [Русский язык](https://github.com/expressjs/multer/blob/main/doc/README-ru.md) (Russe)
-- [Việt Nam](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (Vietnamien)
+- [Việt Name](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (Vietnamien)
 - [Português](https://github.com/expressjs/multer/blob/main/doc/README-pt-br.md) (Portugais du Brésil)
 - [Français](https://github.com/expressjs/multer/blob/main/doc/README-fr.md) (Français)
 
@@ -26,9 +26,9 @@ $ npm install --save multer
 
 ## Usage
 
-Multer ajoute un objet `body` et un objet `file` ou `files` à l'objet `request`. L'objet `body` contient les valeurs des champs texte du formulaire, l'objet `file` ou `files` contient les fichiers téléchargés via le formulaire.
+Multer ajoute un object `body` et un object `file` ou `files` à l'object `request`. L'object `body` contient les valeurs des champs texte du formulaire, l'object `file` ou `files` contient les fichiers téléchargés via le formulaire.
 
-Exemple d'utilisation de base :
+Example d'utilisation de base :
 
 N'oubliez pas le `enctype="multipart/form-data"` dans votre formulaire.
 
@@ -57,7 +57,7 @@ app.post('/photos/upload', upload.array('photos', 12), function (req, res, next)
 
 const uploadMiddleware = upload.fields([{ name: 'avatar', maxCount: 1 }, { name: 'gallery', maxCount: 8 }])
 app.post('/cool-profile', uploadMiddleware, function (req, res, next) {
-  // req.files est un objet (String -> Array) où fieldname est la clé et la valeur est un tableau de fichiers
+  // req.files est un object (String -> Array) où fieldname est la clé et la valeur est un tableau de fichiers
   //
   // e.g.
   //  req.files['avatar'][0] -> Fichier
@@ -80,7 +80,7 @@ app.post('/profile', upload.none(), function (req, res, next) {
 })
 ```
 
-Voici un exemple d'utilisation de multer dans un formulaire HTML. Faites particulièrement attention aux champs `enctype="multipart/form-data"` et `name="uploaded_file"`:
+Voici un example d'utilisation de multer dans un formulaire HTML. Faites particulièrement attention aux champs `enctype="multipart/form-data"` et `name="uploaded_file"`:
 
 ```html
 <form action="/stats" enctype="multipart/form-data" method="post">
@@ -92,7 +92,7 @@ Voici un exemple d'utilisation de multer dans un formulaire HTML. Faites particu
 </form>
 ```
 
-Ensuite, dans votre fichier javascript, vous ajouterez ces lignes pour accéder à la fois au fichier et au corps. Il est important que vous utilisiez la valeur du champ `name` du formulaire dans votre fonction de téléchargement. Cela indique à Multer dans quel champ de la requête il doit rechercher les fichiers. Si ces champs ne sont pas les mêmes dans le formulaire HTML et sur votre serveur, votre téléchargement échouera:
+Ensuite, dans votre fichier javascript, vous ajouterez ces lignes pour accéder à la fois au fichier et au corps. Il est important que vous utilisiez la valeur du champ `name` du formulaire dans votre function de téléchargement. Cela indique à Multer dans quel champ de la requête il doit rechercher les fichiers. Si ces champs ne sont pas les mêmes dans le formulaire HTML et sur votre serveur, votre téléchargement échouera:
 ```javascript
 const multer  = require('multer')
 const upload = multer({ dest: './public/data/uploads/' })
@@ -104,9 +104,9 @@ app.post('/stats', upload.single('uploaded_file'), function (req, res) {
 ```
 ## API
 
-### Informations sur les fichiers
+### Information sur les fichiers
 
-Chaque fichier contient les informations suivantes:
+Chaque fichier contient les information suivantes:
 
 Clé | Description                                    | Notes
 --- |------------------------------------------------| ---
@@ -117,27 +117,27 @@ Clé | Description                                    | Notes
 `size` | Taille du fichier en octets                      |
 `destination` | TLe dossier dans lequel le fichier a été enregistré    | `DiskStorage`
 `filename` | Le nom du fichier dans la `destination`    | `DiskStorage`
-`path` | Le chemin d'accès complet au fichier téléchargé             | `DiskStorage`
+`path` | Le chemin d'accès complete au fichier téléchargé             | `DiskStorage`
 `buffer` | Un `Buffer` du fichier entier                  | `MemoryStorage`
 
 ### `multer(opts)`
 
-Multer accepte un objet d'options, dont le plus basique est le `dest`
+Multer accepte un object d'options, dont le plus basique est le `dest`
 propriété, qui indique à Multer où télécharger les fichiers. Au cas où vous omettez l'objet
 options, les fichiers seront conservés en mémoire et ne seront jamais écrits sur le disque.
 
-Par défaut, Multer renommera les fichiers afin d'éviter les conflits de nommage. Les
-la fonction de renommage peut être personnalisée en fonction de vos besoins.
+Par défaut, Multer renommera les fichiers afin d'éviter les conflicts de nommage. Les
+la function de renommage peut être personnalisée en function de vos besoins.
 
 Voici les options qui peuvent être transmises à Multer.
 
 Clé | Description
 --- | ---
 `dest` ou `storage` | Où stocker les fichiers
-`fileFilter` | Fonction pour contrôler quels fichiers sont acceptés
+`fileFilter` | Function pour contrôler quels fichiers sont acceptés
 `limits` | Limites des données téléchargées
-`preservePath` | Conservez le chemin complet des fichiers au lieu du nom de base uniquement
-`defParamCharset` | Jeu de caractères par défaut à utiliser pour les valeurs des paramètres d'en-tête de partie (par exemple, nom de fichier) qui ne sont pas des paramètres étendus (qui contiennent un jeu de caractères explicite). Par défaut : `'latin1'`
+`preservePath` | Conservez le chemin complete des fichiers au lieu du nom de base uniquement
+`defParamCharset` | Jeu de caractères par défaut à utiliser pour les valeurs des paramètres d'en-tête de partie (par example, nom de fichier) qui ne sont pas des paramètres étendus (qui contiennent un jeu de caractères explicite). Par défaut : `'latin1'`
 
 Dans une application Web moyenne, seul `dest` peut être requis et configuré comme indiqué dans
 l'exemple suivant.
@@ -147,8 +147,8 @@ const upload = multer({ dest: 'uploads/' })
 ```
 
 Si vous voulez plus de contrôle sur vos téléchargements, vous voudrez utiliser le `storage`
-option au lieu de `dest`. Multer est livré avec des moteurs de stockage `DiskStorage`
-et `MemoryStorage`; D'autres moteurs sont disponibles auprès de tiers.
+option au lieu de `dest`. Multer est livré avec des motors de stockage `DiskStorage`
+et `MemoryStorage`; D'autres motors sont disponibles auprès de tiers.
 
 #### `.single(fieldname)`
 
@@ -163,11 +163,11 @@ plus de `maxCount` fichiers sont téléchargés. Le tableau de fichiers sera sto
 
 #### `.fields(fields)`
 
-Accepte un mélange de fichiers, spécifié par `fields`. Un objet avec des tableaux de fichiers
+Accepte un mélange de fichiers, spécifié par `fields`. Un object avec des tableaux de fichiers
 seront stockés dans `req.files`.
 
 `fields` doit être un tableau d'objets avec `name` et éventuellement un `maxCount`.
-Exemple:
+Example:
 
 ```javascript
 [
@@ -188,14 +188,14 @@ Accepte tous les fichiers qui arrivent sur le fil. Un tableau de fichiers sera s
 
 **ATTENTION:** Assurez-vous de toujours gérer les fichiers qu'un utilisateur télécharge.
 N'ajoutez jamais multer en tant que middleware global car un utilisateur malveillant pourrait télécharger des
-fichiers vers un itinéraire que vous n'aviez pas prévu. N'utilisez cette fonction que sur les itinéraires
+fichiers vers un itinéraire que vous n'aviez pas prévu. N'utilisez cette function que sur les itinéraires
 où vous gérez les fichiers téléchargés.
 
 ### `storage`
 
 #### `DiskStorage`
 
-Le moteur de stockage sur disque vous donne un contrôle total sur le stockage des fichiers sur le disque.
+Le motor de stockage sur disque vous donne un contrôle total sur le stockage des fichiers sur le disque.
 
 ```javascript
 const storage = multer.diskStorage({
@@ -212,25 +212,25 @@ const upload = multer({ storage: storage })
 ```
 
 Il y a deux options disponibles, `destination` et `filename`. Elles sont toutes les deux
-des fonctions qui déterminent où le fichier doit être stocké.
+des functions qui déterminent où le fichier doit être stocké.
 
 `destination` est utilisé pour déterminer dans quel dossier les fichiers téléchargés doivent
-être stocké. Cela peut également être donné sous forme de `string` (par exemple `'/tmp/uploads'`). Sinon
+être stocké. Cela peut également être donné sous forme de `string` (par example `'/tmp/uploads'`). Sinon
 `destination` est donné, le répertoire par défaut du système d'exploitation est utilisé pour les
 fichiers temporaires.
 
-**Remarque:** Vous êtes responsable de la création du répertoire lorsque vous fournissez
-`destination` en tant que fonction. Lors du passage d'une chaîne, multer s'assurera que
+**Remarque:** Vous êtes responsible de la création du répertoire lorsque vous fournissez
+`destination` en tant que function. Lors du passage d'une chaîne, multer s'assurera que
 le répertoire est créé pour vous.
 
 `filename` est utilisé pour déterminer le nom du fichier dans le dossier.
 Si aucun "nom de fichier" n'est donné, chaque fichier recevra un nom aléatoire qui n'inclut
 pas d'extension de fichier.
 
-**Remarque:** Multer n'ajoutera aucune extension de fichier pour vous, votre fonction
-doit renvoyer un nom de fichier complet avec une extension de fichier.
+**Remarque:** Multer n'ajoutera aucune extension de fichier pour vous, votre function
+doit renvoyer un nom de fichier complete avec une extension de fichier.
 
-Chaque fonction reçoit à la fois la requête (`req`) et des informations sur
+Chaque function reçoit à la fois la requête (`req`) et des information sur
 le dossier (`file`) pour aider à la décision.
 
 Notez que `req.body` n'a peut-être pas encore été entièrement rempli. Cela dépend de l'ordre
@@ -242,7 +242,7 @@ null comme premier paramètre), reportez-vous à
 
 #### `MemoryStorage`
 
-Le moteur de stockage en mémoire stocke les fichiers en mémoire en tant qu'objets `Buffer`. Il
+Le motor de stockage en mémoire stocke les fichiers en mémoire en tant qu'objets `Buffer`. Il
 n'a pas d'options.
 
 ```javascript
@@ -250,7 +250,7 @@ const storage = multer.memoryStorage()
 const upload = multer({ storage: storage })
 ```
 
-Lors de l'utilisation du stockage en mémoire, les informations sur le fichier contiendront un champ appelé
+Lors de l'utilisation du stockage en mémoire, les information sur le fichier contiendront un champ appelé
 `buffer` qui contient le fichier entier.
 
 **ATTENTION**: Le téléchargement de fichiers très volumineux ou de fichiers relativement petits en grand
@@ -259,7 +259,7 @@ le stockage en mémoire est utilisé.
 
 ### `limits`
 
-Un objet spécifiant les limites de taille des propriétés facultatives suivantes. Multer passe directement cet objet dans busboy, et les détails des propriétés peuvent être trouvés sur [la page de busboy](https://github.com/mscdex/busboy#busboy-methods).
+Un object spécifiant les limites de taille des propriétés facultatives suivantes. Multer passe directement cet object dans busboy, et les détails des propriétés peuvent être trouvés sur [la page de busboy](https://github.com/mscdex/busboy#busboy-methods).
 
 Les valeurs entières suivantes sont disponibles :
 
@@ -277,13 +277,13 @@ Spécifier les limites peut aider à protéger votre site contre les attaques pa
 
 ### `fileFilter`
 
-Définissez ceci sur une fonction pour contrôler quels fichiers doivent être téléchargés et lesquels
-devrait être ignoré. La fonction devrait ressembler à ceci:
+Définissez ceci sur une function pour contrôler quels fichiers doivent être téléchargés et lesquels
+devrait être ignoré. La function devrait ressembler à ceci:
 
 ```javascript
 function fileFilter (req, file, cb) {
 
-  // La fonction doit appeler `cb` avec un booléen
+  // La function doit appeler `cb` avec un booléen
   // pour indiquer si le fichier doit être accepté
 
   // Pour rejeter ce fichier, passez `false`, comme ceci:
@@ -304,7 +304,7 @@ En cas d'erreur, Multer déléguera l'erreur à Express. Vous pouvez
 afficher une belle page d'erreur en utilisant [la voie express standard](http://expressjs.com/guide/error-handling.html).
 
 Si vous souhaitez détecter les erreurs spécifiquement de Multer, vous pouvez appeler la
-fonction middleware par vous-même. Aussi, si vous voulez attraper seulement [les erreurs Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), vous pouvez utiliser la classe `MulterError` qui est jointe à l'objet `multer` lui-même (par exemple `err instanceof multer.MulterError`).
+function middleware par vous-même. Aussi, si vous voulez attraper seulement [les erreurs Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), vous pouvez utiliser la classe `MulterError` qui est jointe à l'objet `multer` lui-même (par example `err instanceof multer.MulterError`).
 
 ```javascript
 const multer = require('multer')
@@ -323,9 +323,9 @@ app.post('/profile', function (req, res) {
 })
 ```
 
-## Moteur de stockage personnalisé
+## Motor de stockage personnalisé
 
-Pour plus d'informations sur la création de votre propre moteur de stockage, consultez [Multer Storage Engine](https://github.com/expressjs/multer/blob/main/StorageEngine.md).
+Pour plus d'informations sur la création de votre propre motor de stockage, consultez [Multer Storage Engine](https://github.com/expressjs/multer/blob/main/StorageEngine.md).
 
 ## License
 

--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -14,7 +14,7 @@ Este README também está disponível em outros idiomas:
 - [简体中文](https://github.com/expressjs/multer/blob/main/doc/README-zh-cn.md) (Chinês)
 - [한국어](https://github.com/expressjs/multer/blob/main/doc/README-ko.md) (Coreano)
 - [Русский язык](https://github.com/expressjs/multer/blob/main/doc/README-ru.md) (Russo)
-- [Việt Nam](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (Vietnã)
+- [Việt Name](https://github.com/expressjs/multer/blob/main/doc/README-vi.md) (Vietnã)
 - [Português](https://github.com/expressjs/multer/blob/main/doc/README-pt-br.md) (Português Brasil)
 - [Français](https://github.com/expressjs/multer/blob/main/doc/README-fr.md) (Francês)
 - [O'zbek tili](https://github.com/expressjs/multer/blob/main/doc/README-uz.md) (Uzbequistão)
@@ -99,7 +99,7 @@ Então, em seu arquivo javascript, você adicionaria essas linhas para acessar o
 const multer  = require('multer')
 const upload = multer({ dest: './public/data/uploads/' })
 app.post('/stats', upload.single('uploaded_file'), function (req, res) {
-  // req.fileé o nome do seu arquivo no formato acima, aqui 'uploaded_file'
+  // req.fileé o gnome do seu arquivo no formato acima, aqui 'uploaded_file'
   // req.body irá conter os campos de texto, se houver algum
   console.log(req.file, req.body)
 });
@@ -113,13 +113,13 @@ Cada arquivo contém as seguintes informações:
 
 Key | Descrição | Nota
 --- | --- | ---
-`fieldname` | Nome do campo especificado no formulário |
-`originalname` | Nome do arquivo no computador do usuário |
+`fieldname` | Gnome do campo especificado no formulário |
+`originalname` | Gnome do arquivo no computador do usuário |
 `encoding` | Tipo de codificação do arquivo |
 `mimetype` | Tipo Mime do arquivo |
 `size` | Tamanho do arquivo em bytes |
 `destination` | A pasta na qual o arquivo foi salvo | `DiskStorage`
-`filename` | O nome do arquivo dentro do `destination` | `DiskStorage`
+`filename` | O gnome do arquivo dentro do `destination` | `DiskStorage`
 `path` | O caminho completo para o arquivo enviado | `DiskStorage`
 `buffer` | O `Buffer` do arquivo inteiro | `MemoryStorage`
 
@@ -127,19 +127,19 @@ Key | Descrição | Nota
 
 Multer aceita um objeto de opções, a propriedade mais básica é o `dest`, que diz ao Multer onde fazer o upload dos arquivos. No caso de você omitir o objeto de opções, os arquivos serão mantidos na memória e nunca gravados no disco.
 
-Por padrão, Multer irá renomear os arquivos para evitar conflitos de nomes. A função de renomeação pode ser personalizada de acordo com suas necessidades.
+Por padrão, Multer irá renomear os arquivos para evitar conflitos de gnomes. A função de renomeação pode set personalizada de acordo com suas necessidades.
 
-A seguir estão as opções que podem ser passadas para o Multer.
+A seguir estão as opções que podem set passadas para o Multer.
 
 Key | Descrição
 --- | ---
 `dest` ou `storage` | Onde armazenar os arquivos
 `fileFilter` | Função para controlar quais arquivos são aceitos
 `limits` | Limites dos dados enviados
-`preservePath` | Mantenha o caminho completo dos arquivos em vez de apenas o nome base
-`defParamCharset` | Conjunto de caracteres padrão para usar em valores de parâmetros de cabeçalho de parte (por exemplo, nome do arquivo) que não são parâmetros estendidos (que contêm um conjunto de caracteres explícito). Padrão: `'latin1'`
+`preservePath` | Mantenha o caminho completo dos arquivos em vez de apenas o gnome base
+`defParamCharset` | Conjunto de characters padrão para usar em valores de parâmetros de cabeçalho de parte (por exemplo, gnome do arquivo) que não são parâmetros estendidos (que contêm um conjunto de characters explícito). Padrão: `'latin1'`
 
-Em um web app básico, somente o `dest` pode ser necessário, e configurado como mostrado no exemplo a seguir:
+Em um web app básico, somente o `dest` pode set necessário, e configurado como mostrado no exemplo a seguir:
 
 ```javascript
 const upload = multer({ dest: 'uploads/' })
@@ -149,18 +149,18 @@ Se você quiser mais controle sobre seus envios, você ter que usar a opção `s
 
 #### `.single(fieldname)`
 
-Aceite um único arquivo com o nome `fieldname`. O arquivo único será armazenado em `req.file`.
+Aceite um único arquivo com o gnome `fieldname`. O arquivo único será armazenado em `req.file`.
 
 #### `.array(fieldname[, maxCount])`
 
-Aceite múltiplos arquivos, todos com o nome `fieldname`. Opcional, gera um erro se forem enviados mais de `maxCount`. O array de arquivos serão armazenados em
+Aceite múltiplos arquivos, todos com o gnome `fieldname`. Opcional, gera um error se forem enviados mais de `maxCount`. O array de arquivos serão armazenados em
 `req.files`.
 
 #### `.fields(fields)`
 
 Aceita uma mistura de arquivos, especificada por `fields`. Um objeto com um array de arquivos será armazenado em `req.files`.
 
-`fields` deve ser uma matriz de objetos com `name` e opcionalmente com `maxCount`.
+`fields` deve set uma matriz de objetos com `name` e opcionalmente com `maxCount`.
 
 Exemplo:
 
@@ -173,7 +173,7 @@ Exemplo:
 
 #### `.none()`
 
-Aceite apenas campo de texto. Se algum upload de arquivo for feito, um erro com código "LIMIT\_UNEXPECTED\_FILE" será emitido.
+Aceite apenas campo de texto. Se algum upload de arquivo for feito, um error com código "LIMIT\_UNEXPECTED\_FILE" será emitido.
 
 #### `.any()`
 
@@ -202,16 +202,16 @@ const storage = multer.diskStorage({
 const upload = multer({ storage: storage })
 ```
 
-Existem duas opções disponíveis, `destination` e `filename`. Ambas são funções que determinam onde o arquivo deve ser armazenado.
+Existem duas opções disponíveis, `destination` e `filename`. Ambas são funções que determinam onde o arquivo deve set armazenado.
 
-`destination` é usado para determinar em qual pasta os arquivos enviados devem ser armazenados. Isso também pode ser dado como uma `string` (e.g. `'/tmp/uploads'`). Se não é dada `destination`, o diretório padrão do sistema operacional para arquivos temporários é usado.
+`destination` é usado para determinar em qual pasta os arquivos enviados devem set armazenados. Isso também pode set dado como uma `string` (e.g. `'/tmp/uploads'`). Se não é dada `destination`, o diretório padrão do sistema operacional para arquivos temporários é usado.
 
 **Nota:** Você é responsável por criar o diretório ao fornecer o "destino" com uma função. Ao passar uma string, o Multer se certificará de que o diretório foi criado para você.
 
-`filename` é usado para determinar qual arquivo deve ser nomeado dentro da pasta.
-Se não for passado `filename`, cada arquivo receberá um nome aleatório que não inclui nenhuma extensão de arquivo.
+`filename` é usado para determinar qual arquivo deve set nomeado dentro da pasta.
+Se não for passado `filename`, cada arquivo receberá um gnome aleatório que não inclui nenhuma extensão de arquivo.
 
-**Nota:** Multer não adicionará nenhuma extensão de arquivo para você, sua função é retornar um nome para o arquivo completo com a extensão de arquivo.
+**Nota:** Multer não adicionará nenhuma extensão de arquivo para você, sua função é retornar um gnome para o arquivo completo com a extensão de arquivo.
 
 Cada função é passada pelo request (`req`) e algumas informações sobre o arquivo (`file`) para ajudar com a decisão.
 
@@ -219,7 +219,7 @@ Observe que `req.body` pode não ter sido totalmente preenchido ainda. Isso depe
 
 Para entender a convenção de chamada usada no callback (precisando passar
 null como o primeiro parâmetro), consulte em
-[Manipulação de erros no Node.js](https://web.archive.org/web/20220417042018/https://www.joyent.com/node-js/production/design/errors)
+[Manipulação de errors no Node.js](https://web.archive.org/web/20220417042018/https://www.joyent.com/node-js/production/design/errors)
 
 #### `MemoryStorage`
 
@@ -234,13 +234,13 @@ Ao usar o armazenamento de memória, as informações do arquivo conterão um ca
 
 ### `limits`
 
-Um objeto que especifica os limites de tamanho das seguintes propriedades opcionais. O Multer passa diretamente o objeto para o busboy, e os detalhes das propriedades podem ser encontrados em [busboy's page](https://github.com/mscdex/busboy#busboy-methods).
+Um objeto que especifica os limites de tamanho das seguintes propriedades opcionais. O Multer passa diretamente o objeto para o busboy, e os detalhes das propriedades podem set encontrados em [busboy's page](https://github.com/mscdex/busboy#busboy-methods).
 
 Os seguintes valores inteiros estão disponíveis:
 
 Key | Descrição | Padrão
 --- | --- | ---
-`fieldNameSize` | Tamanho máximo do nome de campo| 100 bytes
+`fieldNameSize` | Tamanho máximo do gnome de campo| 100 bytes
 `fieldSize` | Tamanho máximo do valor do campo (in bytes) | 1MB
 `fields` | Max number of non-file fields | Infinity
 `fileSize` | Para formulários multipart, o tamanho máximo do arquivo (in bytes) | Infinity
@@ -252,7 +252,7 @@ A especificação dos limites pode ajudar a proteger seu site contra ataques de 
 
 ### `fileFilter`
 
-Defina isso para uma função para controlar quais arquivos devem ser enviados e quais devem ser ignorados.
+Defina isso para uma função para controlar quais arquivos devem set enviados e quais devem set ignorados.
 
 A função deve ficar assim:
 
@@ -260,7 +260,7 @@ A função deve ficar assim:
 function fileFilter (req, file, cb) {
 
   // A função deve chamar `cb` com um booleano
-  // para indicar se o arquivo deve ser aceito
+  // para indicar se o arquivo deve set aceito
 
   // Para rejeitar este arquivo passe `false`, assim:
   cb(null, false)
@@ -268,7 +268,7 @@ function fileFilter (req, file, cb) {
   // Para aceitar o arquivo passe `true`, assim:
   cb(null, true)
 
-  // Você sempre pode passar um erro se algo der errado:
+  // Você sempre pode passar um error se algo der errado:
   cb(new Error('I don\'t have a clue!'))
 
 }
@@ -276,9 +276,9 @@ function fileFilter (req, file, cb) {
 
 ## Error handling
 
-Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibir uma boa página de erro usando [the standard express way](http://expressjs.com/guide/error-handling.html).
+Quando encontrar um error, Multer delegará o error para Express. Você pode exibir uma boa página de error usando [the standard express way](http://expressjs.com/guide/error-handling.html).
 
-Se você quer pegar erros especificamente do Multer, você pode enviar para o função de middleware. Além disso, se você quiser pegar apenas [os erros do Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), você pode usar a classe `MulterError` que está ligado ao objeto `multer` (e.g. `err instanceof multer.MulterError`).
+Se você quer pegar errors especificamente do Multer, você pode enviar para o função de middleware. Além disso, se você quiser pegar apenas [os errors do Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), você pode usar a classe `MulterError` que está ligado ao objeto `multer` (e.g. `err instanceof multer.MulterError`).
 
 ```javascript
 const multer = require('multer')
@@ -287,9 +287,9 @@ const upload = multer().single('avatar')
 app.post('/profile', function (req, res) {
   upload(req, res, function (err) {
     if (err instanceof multer.MulterError) {
-      // Ocorreu um erro durante o upload.
+      // Ocorreu um error durante o upload.
     } else if (err) {
-      // Ocorreu um erro durante o upload.
+      // Ocorreu um error durante o upload.
     }
 
     // Tudo correu bem.

--- a/doc/README-tr.md
+++ b/doc/README-tr.md
@@ -19,7 +19,7 @@ Bu README dosyası ayrıca diğer dillerde de mevcuttur:
 | [Русский язык](https://github.com/expressjs/multer/blob/main/doc/README-ru.md) | Rusça           |
 | [Español](https://github.com/expressjs/multer/blob/main/doc/README-es.md)      | İspanyolca      |
 | [O'zbek tili](https://github.com/expressjs/multer/blob/main/doc/README-uz.md)  | Özbekçe         |
-| [Việt Nam](https://github.com/expressjs/multer/blob/main/doc/README-vi.md)     | Vietnamca       |
+| [Việt Name](https://github.com/expressjs/multer/blob/main/doc/README-vi.md)     | Vietnamca       |
 | [Türkçe](https://github.com/expressjs/multer/blob/main/doc/README-tr.md)       | Türkçe          |
 
 ## Kurulum
@@ -205,7 +205,7 @@ Ağ üzerinden gelen tüm dosyaları kabul eder. Bir dizi dosya
 `req.files` içinde saklanacaktır.
 
 **UYARI:** Kullanıcıların yüklediği dosyaları her zaman kendiniz işlediğinizden emin olun.
-Kötü niyetli bir kullanıcı, sizin öngörmediğiniz bir rotaya dosya yükleyebileceğinden, multer'ı asla global bir orta katman yazılımı olarak eklemeyin.
+Kötü niyetli bir kullanıcı, sizing öngörmediğiniz bir rotaya dosya yükleyebileceğinden, multer'ı asla global bir orta katman yazılımı olarak eklemeyin.
 Bu işlevi yalnızca, yüklenen dosyaları işlediğiniz rotalarda kullanın.
 
 
@@ -238,13 +238,13 @@ saklanacağını belirlemek için kullanılır. Bu, `string` olarak da verilebil
 dizini kullanılır.
 
 **Not:** `destination` işlevini kullanarak dizin oluşturmaktan siz
-sorumlusunuz. Bir string aktardığınızda, multer dizin sizin için
+sorumlusunuz. Bir string aktardığınızda, multer dizin sizing için
 oluşturulduğundan emin olacaktır.
 
 `filename`, dosyanın klasör içinde nasıl adlandırılacağını belirlemek için kullanılır.
 `filename` belirtilmezse, her dosyaya dosya uzantısı içermeyen rastgele bir ad verilir.
 
-**Not:** Multer sizin için herhangi bir dosya uzantısı eklemez, işleviniz
+**Not:** Multer sizing için herhangi bir dosya uzantısı eklemez, işleviniz
 dosya uzantısı ile birlikte tam bir dosya adı döndürmelidir.
 
 Her fonksiyona, karar vermeyi kolaylaştırmak için hem istek (`req`) hem de dosya
@@ -253,7 +253,7 @@ hakkında bazı bilgiler (`file`) aktarılır.
 `req.body`'nin henüz tam olarak doldurulmamış olabileceğini unutmayın. Bu,
 istemcinin alanları ve dosyaları sunucuya aktarma sırasına bağlıdır.
 
-Geri aramada kullanılan çağırma kuralını anlamak için (ilk parametre olarak null geçilmesi gerekir),
+Geri aramada kullanılan çağırma kuralını anlamak için (ilk parameter olarak null geçilmesi gerekir),
 [Node.js hata işleme](https://web.archive.org/web/20220417042018/https://www.joyent.com/node-js/production/design/errors)
 
 #### `MemoryStorage`
@@ -316,7 +316,7 @@ function fileFilter(req, file, cb) {
 ## Hata Yönetimi 
 
 Bir hatayla karşılaşıldığında, Multer hatayı Express'e devreder.
-[Standart Express yöntemi](http://expressjs.com/guide/error-handling.html) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
+[Standard Express yöntemi](http://expressjs.com/guide/error-handling.html) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
 
 Özellikle Multer'dan gelen hataları yakalamak istiyorsanız,
 orta katman işlevini kendiniz çağırabilirsiniz. Ayrıca, yalnızca [Multer hatalarını](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) yakalamak istiyorsanız, `multer` nesnesine eklenmiş olan `MulterError` sınıfını kullanabilirsiniz (ör. `err instanceof multer.MulterError`).

--- a/doc/README-uz.md
+++ b/doc/README-uz.md
@@ -103,7 +103,7 @@ Kalit(key) | Ta'rif                                 | Eslatma
 Multer qo'shimcha ob'ekt qabul qiladi, ulardan eng asosiysi - `dest`,
 Multerga fayllarni qayerga yuklash kerakligini aytadigan xususiyat. Agarda siz qo'shimcha(`options`) ob'ektni tashlab ketsangiz, fayllar xotirada saqlanadi va hech qachon diskka yozilmaydi.
 
-Standart holatda - Multer nomlashda kelib chiqishi mumkin bo'lgan muammolarni oldini olish uchun fayllar nomini o'zgartiradi. O'z talablaringizga mos ravishda nomlash funksiyasini sozlay olashingiz mumkin.
+Standard holatda - Multer nomlashda kelib chiqishi mumkin bo'lgan muammolarni oldini olish uchun fayllar nomini o'zgartiradi. O'z talablaringizga mos ravishda nomlash funksiyasini sozlay olashingiz mumkin.
 
 Quyidagilar Multerga qo'shimcha qiymat sifati berilishi mumkin:
 
@@ -113,7 +113,7 @@ Kalit(key) | Ta'rif
 `fileFilter` | Qaysi fayllar qabul qilinishini boshqarish funksiyasi
 `limits` | Yuklash chegarasi
 `preservePath` | Asosiy nom o'rniga fayllarning to'liq yo'lini saqlash
-`defParamCharset` | Kengaytirilgan parametrlar bo'lmagan qism sarlavha parametrlari qiymatlari (masalan, fayl nomi) uchun ishlatish uchun standart belgilar to'plami (aniq belgilar to'plamini o'z ichiga olmaydi). Standart: `'latin1'`
+`defParamCharset` | Kengaytirilgan parametrlar bo'lmagan qism sarlavha parametrlari qiymatlari (masalan, fayl nomi) uchun ishlatish uchun standard belgilar to'plami (aniq belgilar to'plamini o'z ichiga olmaydi). Standard: `'latin1'`
 
 O'rtacha veb-ilovada faqat `dest` kerak bo'lishi mumkin va quyidagicha sozlanishi mumkin
 
@@ -186,7 +186,7 @@ Har bir funksiya `req` so'rovini va fayl haqida ma'lumotlarni (`file`) olish uch
 
 Diqqat qiling, `req.body` hali to'liq to'ldirilmagan bo'lishi mumkin. Bu mijozning maydon(field)larni va fayllarni serverga qanday yuborishiga bog'liq bo'ladi.
 
-Callback funktsiyasida ishlatiladigan chaqirish tartibini tushunish uchun (birinchi parametr sifatida null o‘tkazish talab etilishi) ko‘rish uchun quyidagi manzilga murojaat qiling:
+Callback funktsiyasida ishlatiladigan chaqirish tartibini tushunish uchun (birinchi parameter sifatida null o‘tkazish talab etilishi) ko‘rish uchun quyidagi manzilga murojaat qiling:
 [Node.js da xatoliklarni ushlash](https://web.archive.org/web/20220417042018/https://www.joyent.com/node-js/production/design/errors)
 
 #### `MemoryStorage`
@@ -203,7 +203,7 @@ Xotirada saqlash paytida, fayl ma'lumotlari `buffer` deb nomlanadigan maydonni o
 
 ### `limits`
 
-Quyidagi xususiyatlar o'lchov(limit)larni aniqlaydigan obyekt. Multer ushbu obyektni to'g'ridan-to'g'ri busboy ga o'tkazadi va xususiyatlar tafsilotlari [busboy sahifasida](https://github.com/mscdex/busboy#busboy-methods)dan topishingiz mumkin.
+Quyidagi xususiyatlar o'lchov(limit)larni aniqlaydigan object. Multer ushbu obyektni to'g'ridan-to'g'ri busboy ga o'tkazadi va xususiyatlar tafsilotlari [busboy sahifasida](https://github.com/mscdex/busboy#busboy-methods)dan topishingiz mumkin.
 
 Quyidagi butun qiymatlar mavjud:
 
@@ -243,7 +243,7 @@ function fileFilter (req, file, cb) {
 
 ## Xatolar bilan ishlash
 
-Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standart express usuli](http://expressjs.com/guide/error-handling.html)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
+Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standard express usuli](http://expressjs.com/guide/error-handling.html)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
 
 Agar siz Multerdan chiqqan xatolarni aniqlamoqchi bo'lsangiz o'zingiz `middleware` funksiya yozishingiz mumkin. Shuningdek, agar siz faqat [Multer xatolarini](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) ushlamoqchi bo'lsangiz, siz `multer` ob'ektiga yozilgan `MulterError` class ni ishlatishingiz mumkin (masalan, `err instanceof multer.MulterError`).
 

--- a/doc/README-vi.md
+++ b/doc/README-vi.md
@@ -100,7 +100,7 @@ Mỗi file sẽ chứa các thông tin sau:
 | `path`         | Đường dẫn đầy đủ tới file đã upload                             | `DiskStorage`             |
 | `buffer`       | Một `Buffer` của toàn bộ file                                   | `MemoryStorage`           |
 
-### Tham số `multer(opts)`
+### Than số `multer(opts)`
 
 Multer chấp nhận một biến options. Cơ bản là thuộc tính `dest`, là nơi sẽ lưu
 file được upload. Trong trường hợp bỏ qua options này, file sẽ được giữ trong
@@ -117,7 +117,7 @@ Dưới đây là các tùy chọn mà bạn có thể sử dụng:
 | `fileFilter`          | Hàm để xử lý chỉ những file nào mới được chấp nhận |
 | `limits`              | Giới hạn dung lượng file được upload               |
 | `preservePath`        | Giữ đầy đủ đường dẫn tới file thay vì chỉ tên file |
-| `defParamCharset`     | Bộ ký tự mặc định để sử dụng cho các giá trị tham số tiêu đề phần (ví dụ: tên tệp) không phải là tham số mở rộng (không chứa bộ ký tự rõ ràng). Mặc định: `'latin1'` |
+| `defParamCharset`     | Bộ ký tự mặc định để sử dụng cho các giá trị than số tiêu đề phần (ví dụ: tên tệp) không phải là than số mở rộng (không chứa bộ ký tự rõ ràng). Mặc định: `'latin1'` |
 
 Nói chung với web app, chỉ `dest` mới cần khai báo, như bên dưới:
 


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.