### PR TITLE
feat(disk-storage): support opt-in flush for durable uploads (#1381)

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -15,6 +15,14 @@ function getDestination (req, file, cb) {
 
 function DiskStorage (opts) {
   this.getFilename = (opts.filename || getFilename)
+  // When `flush` is truthy, the disk storage asks the underlying write
+  // stream to fdatasync() the uploaded file before `_handleFile` reports
+  // success, so callers that expect the data to survive a crash or power
+  // loss (see #1381) can rely on it. The option is forwarded as
+  // `fs.createWriteStream(..., { flush: true })`, which was added in
+  // Node.js 20.10 / 21.0. On older runtimes the option is ignored and
+  // behavior falls back to the previous buffered-write semantics.
+  this.flush = opts.flush === true
 
   if (typeof opts.destination === 'string') {
     fs.mkdirSync(opts.destination, { recursive: true })
@@ -34,7 +42,8 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
       if (err) return cb(err)
 
       var finalPath = path.join(destination, filename)
-      var outStream = fs.createWriteStream(finalPath)
+      var writeStreamOptions = that.flush ? { flush: true } : undefined
+      var outStream = fs.createWriteStream(finalPath, writeStreamOptions)
 
       file.stream.pipe(outStream)
       outStream.on('error', cb)

--- a/test/disk-storage.js
+++ b/test/disk-storage.js
@@ -185,4 +185,59 @@ describe('Disk Storage', function () {
       done()
     })
   })
+
+  it('should support the flush option for durable uploads (#1381)', function (done) {
+    var calls = []
+    var realCreateWriteStream = fs.createWriteStream
+    fs.createWriteStream = function (filePath, options) {
+      calls.push({ filePath: filePath, options: options })
+      return realCreateWriteStream.apply(fs, arguments)
+    }
+
+    var storage = multer.diskStorage({ destination: uploadDir, flush: true })
+    var flushUpload = multer({ storage: storage })
+    var parser = flushUpload.single('small0')
+
+    var form = new FormData()
+    form.append('small0', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      fs.createWriteStream = realCreateWriteStream
+      assert.ifError(err)
+
+      assert.strictEqual(calls.length, 1)
+      assert.ok(calls[0].options && calls[0].options.flush === true,
+        'expected createWriteStream to be called with { flush: true }')
+
+      assert.strictEqual(req.file.fieldname, 'small0')
+      assert.strictEqual(req.file.size, 1778)
+      assert.strictEqual(util.fileSize(req.file.path), 1778)
+
+      done()
+    })
+  })
+
+  it('should default to buffered writes when flush is not set', function (done) {
+    var calls = []
+    var realCreateWriteStream = fs.createWriteStream
+    fs.createWriteStream = function (filePath, options) {
+      calls.push({ filePath: filePath, options: options })
+      return realCreateWriteStream.apply(fs, arguments)
+    }
+
+    var parser = upload.single('small0')
+    var form = new FormData()
+    form.append('small0', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      fs.createWriteStream = realCreateWriteStream
+      assert.ifError(err)
+
+      assert.strictEqual(calls.length, 1)
+      assert.strictEqual(calls[0].options, undefined,
+        'expected createWriteStream to be called with no options when flush is not set')
+
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Closes #1381.

## Why

As reported in #1381, the disk storage pipes the uploaded file into a vanilla \`fs.createWriteStream\` and reports the upload as successful the moment the stream finishes. On Linux (and any OS with a write-back page cache) the bytes can still be sitting in kernel buffers when the request handler returns, a power loss or crash at the wrong moment leaves the file truncated or zero-length, but the HTTP response already claimed success.

Node.js 20.10 / 21.0 added a \`flush\` option to \`fs.createWriteStream\` that calls \`fdatasync()\` on the file descriptor before the stream closes, which is exactly what this workflow needs.

## Change

Expose \`flush\` as an opt-in \`DiskStorage\` option:

\`\`\`js
multer.diskStorage({
  destination: './uploads',
  flush: true
})
\`\`\`

- Default stays \`false\`, so existing users get the exact same buffered-write behavior and the same throughput, no perf regression.
- When \`flush\` is \`true\`, the option is forwarded as \`fs.createWriteStream(path, { flush: true })\`. On runtimes older than Node 20.10, \`createWriteStream\` silently ignores the option, which matches the documented upstream behavior.
- No change to \`_removeFile\` or error handling.

## Tests

Added two regression tests in \`test/disk-storage.js\`:

1. With \`flush: true\`, the test wraps \`fs.createWriteStream\` and asserts it was called with \`{ flush: true }\` while the upload still round-trips at the expected size.
2. Without \`flush\`, \`createWriteStream\` is still called with no options, verifies the default behavior is unchanged.

Full \`npm test\` suite: **74/74 passing**.