### PR TITLE
docs: use crypto.randomBytes for custom filename example (#1386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,17 @@ where you are handling the uploaded files.
 The disk storage engine gives you full control on storing files to disk.
 
 ```javascript
+const crypto = require('crypto')
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
+    // Use a cryptographically strong suffix so filenames cannot be
+    // guessed or enumerated from a weak PRNG like `Math.random()`. The
+    // built-in `DiskStorage` default uses the same approach.
+    const uniqueSuffix = crypto.randomBytes(16).toString('hex')
     cb(null, file.fieldname + '-' + uniqueSuffix)
   }
 })


### PR DESCRIPTION
Closes #1386.

The custom \`diskStorage\` example in the README uses \`Date.now() + Math.round(Math.random() * 1E9)\` to build the unique filename suffix. That's the pattern production apps copy when they need a custom \`filename\` to keep the file extension or add a field-based prefix, so the insecure form ends up in a lot of deployed code.

The issue is that:
- \`Math.random()\` is not cryptographically secure, V8's xorshift128+ state is recoverable from a small number of outputs (~30 bits of entropy per call).
- \`Date.now()\` contributes ~0 bits of unpredictability when the attacker knows roughly when a file was uploaded.
- If uploads land in a web-accessible directory, the filename space is enumerable → cross-user access without authz.

Multer's own built-in default already uses \`crypto.randomBytes(16)\` (\`storage/disk.js:6-9\`). This PR just updates the README's custom-\`filename\` example to teach the same pattern so copy-paste users get the secure default by construction.

No code changes, docs only.