### PR TITLE
Rename internal errorOccured -> errorOccurred in make-middleware

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -32,7 +32,7 @@ function makeMiddleware (setup) {
     var appender = null
     var isDone = false
     var readFinished = false
-    var errorOccured = false
+    var errorOccurred = false
     var pendingWrites = new Counter()
     var uploadedFiles = []
 
@@ -70,12 +70,12 @@ function makeMiddleware (setup) {
     }
 
     function indicateDone () {
-      if (readFinished && pendingWrites.isZero() && !errorOccured) done()
+      if (readFinished && pendingWrites.isZero() && !errorOccurred) done()
     }
 
     function abortWithError (uploadError, skipPendingWait) {
-      if (errorOccured) return
-      errorOccured = true
+      if (errorOccurred) return
+      errorOccurred = true
 
       function finishAbort () {
         function remove (file, cb) {
@@ -181,7 +181,7 @@ function makeMiddleware (setup) {
       var placeholder = appender.insertPlaceholder(file)
 
       fileFilter(req, file, function (err, includeFile) {
-        if (errorOccured) {
+        if (errorOccurred) {
           appender.removePlaceholder(placeholder)
           return fileStream.resume()
         }


### PR DESCRIPTION
`lib/make-middleware.js` keeps a one-shot 'has the upload errored?' flag named `errorOccured` (5 references). The variable is private to the closure that builds the middleware so the rename is invisible to consumers, but it removes a spelling mistake from a high-traffic project.

```
35:    var errorOccured = false
73:      if (readFinished && pendingWrites.isZero() && !errorOccured) done()
77:      if (errorOccured) return
78:      errorOccured = true
184:        if (errorOccured) {
```

Verification:

- `npm test` — all 72 mocha tests pass
- `npm run lint` (`standard`) — clean

Source verified against current `main`.