### PR TITLE
fix(docs): handle string destination in storage engine template

### DIFF
--- a/StorageEngine.md
+++ b/StorageEngine.md
@@ -44,7 +44,11 @@ function getDestination (req, file, cb) {
 }
 
 function MyCustomStorage (opts) {
-  this.getDestination = (opts.destination || getDestination)
+  if (typeof opts.destination === 'string') {
+    this.getDestination = function ($0, $1, cb) { cb(null, opts.destination) }
+  } else {
+    this.getDestination = (opts.destination || getDestination)
+  }
 }
 
 MyCustomStorage.prototype._handleFile = function _handleFile (req, file, cb) {


### PR DESCRIPTION
Closes #1278

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
expressjs/multer

## Issue
https://github.com/expressjs/multer/issues/1278

## Root cause
The `StorageEngine.md` custom storage template assigned `opts.destination`
directly to `this.getDestination` and then invoked it as a function in
`_handleFile`. If a user follows the convention used by `DiskStorage` and
passes `destination` as a string path, the template throws a TypeError
because a string is not callable.

## Fix
Updated the `MyCustomStorage` constructor in `StorageEngine.md` to mirror
the behavior of `storage/disk.js`: when `opts.destination` is a string,
wrap it in a `function ($0, $1, cb) { cb(null, opts.destination) }`
adapter; otherwise fall back to the function-or-default assignment.

## Regression test
None. The change is documentation-only (`StorageEngine.md`); the existing
`storage/disk.js` already correctly handles string destinations and is
covered by `test/disk-storage.js`.

## Risk
trivial

## Verification
skipped: documentation-only change with no executable code path; existing
disk-storage tests cover the equivalent runtime behavior the docs now
reflect.
