### PR TITLE
fix: reject non-integer fileSize limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function Multer (options) {
   }
 
   this.limits = options.limits
+  if (this.limits && this.limits.fileSize != null && !Number.isInteger(this.limits.fileSize)) {
+    throw new TypeError('Expected limits.fileSize to be an integer')
+  }
   this.preservePath = options.preservePath
   this.defParamCharset = options.defParamCharset || 'latin1'
   this.fileFilter = options.fileFilter || allowAll

--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ function Multer (options) {
     this.storage = memoryStorage()
   }
 
+  if (options.limits && options.limits.fileSize != null &&
+    !Number.isInteger(options.limits.fileSize) && options.limits.fileSize !== Infinity) {
+    throw new TypeError('Expected limits.fileSize to be an integer or Infinity')
+  }
+
   this.limits = options.limits
   this.preservePath = options.preservePath
   this.defParamCharset = options.defParamCharset || 'latin1'

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -459,4 +459,16 @@ describe('Error Handling', function () {
       done()
     })
   })
+
+  it('should throw TypeError when fileSize limit is a float', function () {
+    assert.throws(function () {
+      multer({ limits: { fileSize: 1024.5 } })
+    }, TypeError)
+  })
+
+  it('should accept integer fileSize limit', function () {
+    assert.doesNotThrow(function () {
+      multer({ limits: { fileSize: 1024 } })
+    })
+  })
 })

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -528,6 +528,29 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should throw TypeError when fileSize limit is not an integer', function () {
+    // busboy only emits 'limit' when the byte count equals the limit exactly,
+    // so a float limit silently truncates the file instead of rejecting it
+    assert.throws(function () {
+      multer({ limits: { fileSize: 1024.5 } })
+    }, {
+      name: 'TypeError',
+      message: 'Expected limits.fileSize to be an integer or Infinity'
+    })
+
+    assert.throws(function () {
+      multer({ limits: { fileSize: '1024' } })
+    }, TypeError)
+  })
+
+  it('should accept an integer or Infinity fileSize limit', function () {
+    assert.doesNotThrow(function () {
+      multer({ limits: { fileSize: 1024 } })
+      multer({ limits: { fileSize: Infinity } })
+      multer({ limits: {} })
+    })
+  })
+
   it('should throw TypeError if options is not an object', function () {
     assert.throws(() => {
       multer(null)


### PR DESCRIPTION
busboy only emits `limit` when the byte count equals the limit exactly, so a float `limits.fileSize` (e.g. `1024.1`) silently truncates the file to the next byte and accepts it instead of rejecting it. This throws a `TypeError` at construction time unless `fileSize` is an integer or `Infinity` (the default, which keeps working).

Rebased onto `main`; the check now allows `Infinity`, and tests cover the float, string, integer and `Infinity` cases.

Closes #1132