### PR TITLE
fix: preserve existing request body fields

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -26,7 +26,15 @@ function makeMiddleware (setup) {
     var preservePath = options.preservePath
     var defParamCharset = options.defParamCharset
 
+    var existingBody = req.body
+
     req.body = Object.create(null)
+
+    if (existingBody && typeof existingBody === 'object') {
+      Object.keys(existingBody).forEach(function (key) {
+        req.body[key] = existingBody[key]
+      })
+    }
 
     var busboy
     var appender = null

--- a/test/fields.js
+++ b/test/fields.js
@@ -34,6 +34,37 @@ describe('Fields', function () {
     })
   })
 
+  it('should preserve existing body properties', function (done) {
+    var form = new FormData()
+
+    form.append('name', 'Multer')
+
+    form.getLength(function (err, length) {
+      if (err) return done(err)
+
+      var req = new stream.PassThrough()
+
+      form.pipe(req)
+      req.body = {
+        auth: true,
+        limit: 66
+      }
+      req.headers = {
+        'content-type': 'multipart/form-data; boundary=' + form.getBoundary(),
+        'content-length': length
+      }
+
+      parser(req, null, function (err) {
+        assert.ifError(err)
+        assert.strictEqual(Object.getPrototypeOf(req.body), null)
+        assert.strictEqual(req.body.auth, true)
+        assert.strictEqual(req.body.limit, 66)
+        assert.strictEqual(req.body.name, 'Multer')
+        done()
+      })
+    })
+  })
+
   it('should process empty fields', function (done) {
     var form = new FormData()
 


### PR DESCRIPTION
## Summary

Preserve existing own `req.body` properties when Multer initializes multipart parsing, instead of replacing them with an empty object.

Multer still uses a null-prototype object for `req.body`; it copies existing own enumerable properties into that object before appending multipart fields.

Fixes #1187.

## Validation

- `npm run lint`
- `npx mocha --reporter spec --exit --check-leaks test/fields.js`

I also ran `npm test`; it reached the new regression successfully, but the full suite fails in this Windows checkout on existing fixture byte-size and POSIX path assertions unrelated to this change, for example `1803 !== 1778` in storage/file size tests and `/testforme-` path matching.