### PR TITLE
Fix multipart boundaries containing equals signs

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -13,9 +13,40 @@ function drainStream (stream) {
   })
 }
 
+function isMultipart (req) {
+  var type = req.headers && req.headers['content-type']
+
+  return type && is.hasBody(req) &&
+    type.split(';')[0].trim().toLowerCase().indexOf('multipart/') === 0
+}
+
+function normalizeMultipartHeaders (headers) {
+  var type = headers['content-type']
+
+  if (typeof type !== 'string' || type.indexOf('=') === -1) {
+    return headers
+  }
+
+  var normalized = type.replace(/(^|;\s*)boundary=([^";\s][^;]*)/i, function (match, prefix, boundary) {
+    if (boundary.indexOf('=') === -1) {
+      return match
+    }
+
+    return prefix + 'boundary="' + boundary.replace(/(["\\])/g, '\\$1') + '"'
+  })
+
+  if (normalized === type) {
+    return headers
+  }
+
+  return Object.assign({}, headers, {
+    'content-type': normalized
+  })
+}
+
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
-    if (!is(req, ['multipart'])) return next()
+    if (!isMultipart(req)) return next()
 
     var options = setup()
 
@@ -125,7 +156,7 @@ function makeMiddleware (setup) {
 
     try {
       busboy = Busboy({
-        headers: req.headers,
+        headers: normalizeMultipartHeaders(req.headers),
         limits: limits,
         preservePath: preservePath,
         defParamCharset: defParamCharset

--- a/test/fields.js
+++ b/test/fields.js
@@ -34,6 +34,33 @@ describe('Fields', function () {
     })
   })
 
+  it('should process multipart boundary containing equals sign', function (done) {
+    var boundary = 'abc=def'
+    var body = Buffer.from(
+      '--' + boundary + '\r\n' +
+      'Content-Disposition: form-data; name="name"\r\n' +
+      '\r\n' +
+      'Multer\r\n' +
+      '--' + boundary + '--\r\n'
+    )
+    var req = new stream.PassThrough()
+
+    req.end(body)
+    req.method = 'POST'
+    req.headers = {
+      'content-type': 'multipart/form-data; boundary=' + boundary,
+      'content-length': body.length
+    }
+
+    parser(req, null, function (err) {
+      assert.ifError(err)
+      assert(deepEqual(req.body, {
+        name: 'Multer'
+      }))
+      done()
+    })
+  })
+
   it('should process empty fields', function (done) {
     var form = new FormData()
 


### PR DESCRIPTION
Fixes #1051.

Multer used `type-is` to detect multipart requests before handing the request to Busboy. `type-is` rejects unquoted multipart boundary parameters containing `=`, even though those boundaries can be parsed by the multipart stream itself. The result was that Multer skipped the request entirely.

This changes the early multipart check to avoid parsing parameters and only inspect the media type while still honoring `type-is.hasBody(req)`. Before constructing Busboy, it normalizes only unquoted boundary values containing `=` by quoting the boundary in the headers passed to Busboy. The original request headers are not mutated.

Validation:
- `npx mocha --reporter spec --exit --check-leaks test/fields.js`
- `npm run lint`
- `npm test` was also run; it still fails on existing Windows fixture-size/path assertions unrelated to this change, while the new fields regression passed.