### PR TITLE
fix: do not reject files whose size equals limits.fileSize

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -123,10 +123,18 @@ function makeMiddleware (setup) {
       handleRequestFailure(new Error('Request closed'))
     })
 
+    var busboyLimits = limits
+    if (limits && Object.prototype.hasOwnProperty.call(limits, 'fileSize') && limits.fileSize != null) {
+      // Busboy emits 'limit' once a file reaches exactly `fileSize` bytes, even
+      // when the file is not actually larger than the limit. Bump the value by
+      // one so the event only fires when the limit is genuinely exceeded.
+      busboyLimits = { ...limits, fileSize: limits.fileSize + 1 }
+    }
+
     try {
       busboy = Busboy({
         headers: req.headers,
-        limits: limits,
+        limits: busboyLimits,
         preservePath: preservePath,
         defParamCharset: defParamCharset
       })

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -66,6 +66,21 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should accept a file whose size equals the file size limit', function (done) {
+    var form = new FormData()
+    var parser = withLimits({ fileSize: 122 }, [
+      { name: 'tiny0', maxCount: 1 }
+    ])
+
+    form.append('tiny0', util.file('tiny0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.files.tiny0[0].size, 122)
+      done()
+    })
+  })
+
   it('should respect file count limit', function (done) {
     var form = new FormData()
     var parser = withLimits({ files: 1 }, [


### PR DESCRIPTION
Busboy emits its `limit` event once a file reaches exactly `fileSize` bytes, so multer rejects uploads that are exactly at the limit with `LIMIT_FILE_SIZE`. This passes `fileSize + 1` down to Busboy so the limit only triggers when the size is genuinely exceeded. Closes #1348.