### PR TITLE
Update outdated links to Express error handling guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ function fileFilter (req, file, cb) {
 ## Error handling
 
 When encountering an error, Multer will delegate the error to Express. You can
-display a nice error page using [the standard express way](http://expressjs.com/guide/error-handling.html).
+display a nice error page using [the standard express way](https://expressjs.com/en/guide/error-handling).
 
 If you want to catch errors specifically from Multer, you can call the
 middleware function by yourself. Also, if you want to catch only [the Multer errors](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), you can use the `MulterError` class that is attached to the `multer` object itself (e.g. `err instanceof multer.MulterError`).

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ function fileFilter (req, file, cb) {
 ## Error handling
 
 When encountering an error, Multer will delegate the error to Express. You can
-display a nice error page using [the standard express way](https://expressjs.com/en/guide/error-handling).
+display a nice error page using [the standard express way](https://expressjs.com/en/guide/error-handling/).
 
 If you want to catch errors specifically from Multer, you can call the
 middleware function by yourself. Also, if you want to catch only [the Multer errors](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), you can use the `MulterError` class that is attached to the `multer` object itself (e.g. `err instanceof multer.MulterError`).

--- a/doc/README-ar.md
+++ b/doc/README-ar.md
@@ -278,7 +278,7 @@ function fileFilter (req, file, cb) {
 ## معالجة الأخطاء
 
 عند مواجهة خطأ ، سيقوم Multer بتفويض الخطأ إلى Express. يمكنك
-عرض صفحة خطأ لطيفة باستخدام [طريقة Express القياسية](http://expressjs.com/guide/error-handling.html).
+عرض صفحة خطأ لطيفة باستخدام [طريقة Express القياسية](https://expressjs.com/en/guide/error-handling).
 
 إذا كنت تريد إنتقاء الأخطاء والحصول على [أخطاء Multer فقط](https://github.com/expressjs/multer/blob/main/lib/multer-error.js)، فيمكنك نداء بدالة الوسيطة من قبل نفسك. أيضًا ، إذا كنت تريد التقاط أخطاء Multer فقط ، فيمكنك استخدام صنف `MulterError` المتصل بالكائن` multer` نفسه (على سبيل المثال `err instanceof multer.MulterError`).
 

--- a/doc/README-ar.md
+++ b/doc/README-ar.md
@@ -278,7 +278,7 @@ function fileFilter (req, file, cb) {
 ## معالجة الأخطاء
 
 عند مواجهة خطأ ، سيقوم Multer بتفويض الخطأ إلى Express. يمكنك
-عرض صفحة خطأ لطيفة باستخدام [طريقة Express القياسية](https://expressjs.com/en/guide/error-handling).
+عرض صفحة خطأ لطيفة باستخدام [طريقة Express القياسية](https://expressjs.com/en/guide/error-handling/).
 
 إذا كنت تريد إنتقاء الأخطاء والحصول على [أخطاء Multer فقط](https://github.com/expressjs/multer/blob/main/lib/multer-error.js)، فيمكنك نداء بدالة الوسيطة من قبل نفسك. أيضًا ، إذا كنت تريد التقاط أخطاء Multer فقط ، فيمكنك استخدام صنف `MulterError` المتصل بالكائن` multer` نفسه (على سبيل المثال `err instanceof multer.MulterError`).
 

--- a/doc/README-es.md
+++ b/doc/README-es.md
@@ -269,7 +269,7 @@ function fileFilter (req, file, cb) {
 
 ## Manejo de errores
 
-Al encontrarse con un error, Multer delegará ese error a Express. Puedes mostrar una linda página de error usando [la manera standard de Express](http://expressjs.com/guide/error-handling.html).
+Al encontrarse con un error, Multer delegará ese error a Express. Puedes mostrar una linda página de error usando [la manera standard de Express](https://expressjs.com/es/guide/error-handling).
 
 Si quieres capturar los errores específicamente desde Multer, puedes llamar la función middleware tú mismo. También, si quieres capturar sólo [los errores de Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), puedes usar la clase `MulterError` que está adherida al mismo objeto `multer` (por ejemplo: `err instanceof multer.MulterError`).
 

--- a/doc/README-es.md
+++ b/doc/README-es.md
@@ -269,7 +269,7 @@ function fileFilter (req, file, cb) {
 
 ## Manejo de errores
 
-Al encontrarse con un error, Multer delegará ese error a Express. Puedes mostrar una linda página de error usando [la manera standard de Express](https://expressjs.com/es/guide/error-handling).
+Al encontrarse con un error, Multer delegará ese error a Express. Puedes mostrar una linda página de error usando [la manera standard de Express](https://expressjs.com/es/guide/error-handling/).
 
 Si quieres capturar los errores específicamente desde Multer, puedes llamar la función middleware tú mismo. También, si quieres capturar sólo [los errores de Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), puedes usar la clase `MulterError` que está adherida al mismo objeto `multer` (por ejemplo: `err instanceof multer.MulterError`).
 

--- a/doc/README-fr.md
+++ b/doc/README-fr.md
@@ -301,7 +301,7 @@ function fileFilter (req, file, cb) {
 ## Gestion des Erreurs
 
 En cas d'erreur, Multer déléguera l'erreur à Express. Vous pouvez
-afficher une belle page d'erreur en utilisant [la voie express standard](http://expressjs.com/guide/error-handling.html).
+afficher une belle page d'erreur en utilisant [la voie express standard](https://expressjs.com/fr/guide/error-handling).
 
 Si vous souhaitez détecter les erreurs spécifiquement de Multer, vous pouvez appeler la
 fonction middleware par vous-même. Aussi, si vous voulez attraper seulement [les erreurs Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), vous pouvez utiliser la classe `MulterError` qui est jointe à l'objet `multer` lui-même (par exemple `err instanceof multer.MulterError`).

--- a/doc/README-fr.md
+++ b/doc/README-fr.md
@@ -301,7 +301,7 @@ function fileFilter (req, file, cb) {
 ## Gestion des Erreurs
 
 En cas d'erreur, Multer déléguera l'erreur à Express. Vous pouvez
-afficher une belle page d'erreur en utilisant [la voie express standard](https://expressjs.com/fr/guide/error-handling).
+afficher une belle page d'erreur en utilisant [la voie express standard](https://expressjs.com/fr/guide/error-handling/).
 
 Si vous souhaitez détecter les erreurs spécifiquement de Multer, vous pouvez appeler la
 fonction middleware par vous-même. Aussi, si vous voulez attraper seulement [les erreurs Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), vous pouvez utiliser la classe `MulterError` qui est jointe à l'objet `multer` lui-même (par exemple `err instanceof multer.MulterError`).

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -231,7 +231,7 @@ function fileFilter (req, file, cb) {
 
 ## 에러 핸들링
 
-에러가 발생할 때, multer는 에러를 express에 위임할 것입니다. 여러분은 [the standard express way](http://expressjs.com/guide/error-handling.html) 를 이용해서 멋진 오류 페이지를 보여줄 수 있습니다.
+에러가 발생할 때, multer는 에러를 express에 위임할 것입니다. 여러분은 [the standard express way](https://expressjs.com/ko/guide/error-handling) 를 이용해서 멋진 오류 페이지를 보여줄 수 있습니다.
 
 만일 multer 로부터 특별히 에러를 캐치하고 싶다면, 직접 미들웨어 함수를 호출하세요.
 

--- a/doc/README-ko.md
+++ b/doc/README-ko.md
@@ -231,7 +231,7 @@ function fileFilter (req, file, cb) {
 
 ## 에러 핸들링
 
-에러가 발생할 때, multer는 에러를 express에 위임할 것입니다. 여러분은 [the standard express way](https://expressjs.com/ko/guide/error-handling) 를 이용해서 멋진 오류 페이지를 보여줄 수 있습니다.
+에러가 발생할 때, multer는 에러를 express에 위임할 것입니다. 여러분은 [the standard express way](https://expressjs.com/ko/guide/error-handling/) 를 이용해서 멋진 오류 페이지를 보여줄 수 있습니다.
 
 만일 multer 로부터 특별히 에러를 캐치하고 싶다면, 직접 미들웨어 함수를 호출하세요.
 

--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -276,7 +276,7 @@ function fileFilter (req, file, cb) {
 
 ## Error handling
 
-Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibir uma boa página de erro usando [the standard express way](http://expressjs.com/guide/error-handling.html).
+Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibir uma boa página de erro usando [the standard express way](https://expressjs.com/pt-br/guide/error-handling).
 
 Se você quer pegar erros especificamente do Multer, você pode enviar para o função de middleware. Além disso, se você quiser pegar apenas [os erros do Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), você pode usar a classe `MulterError` que está ligado ao objeto `multer` (e.g. `err instanceof multer.MulterError`).
 

--- a/doc/README-pt-br.md
+++ b/doc/README-pt-br.md
@@ -276,7 +276,7 @@ function fileFilter (req, file, cb) {
 
 ## Error handling
 
-Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibir uma boa página de erro usando [the standard express way](https://expressjs.com/pt-br/guide/error-handling).
+Quando encontrar um erro, Multer delegará o erro para Express. Você pode exibir uma boa página de erro usando [the standard express way](https://expressjs.com/pt-br/guide/error-handling/).
 
 Se você quer pegar erros especificamente do Multer, você pode enviar para o função de middleware. Além disso, se você quiser pegar apenas [os erros do Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), você pode usar a classe `MulterError` que está ligado ao objeto `multer` (e.g. `err instanceof multer.MulterError`).
 

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -239,7 +239,7 @@ function fileFilter (req, file, cb) {
 
 ## Обработка ошибок
 
-Когда выбрасывается исключение, Multer делегирует его обработку Express. Вы можете выводить страницу ошибки [стандартными для express способами](http://expressjs.com/guide/error-handling.html).
+Когда выбрасывается исключение, Multer делегирует его обработку Express. Вы можете выводить страницу ошибки [стандартными для express способами](https://expressjs.com/en/guide/error-handling).
 
 Если вы хотите отлавливать ошибки конкретно от Multer, вам нужно вызывать собственную middleware для их обработки. Еще, если вы хотите отлавливать [исключительно ошибки Multer](https://github.com/expressjs/multer/blob/main/lib/make-error.js#L1-L9), вы можете использовать класс `MulterError`, который привязан к объекту `multer` (например, `err instanceof multer.MulterError`)
 

--- a/doc/README-ru.md
+++ b/doc/README-ru.md
@@ -239,7 +239,7 @@ function fileFilter (req, file, cb) {
 
 ## Обработка ошибок
 
-Когда выбрасывается исключение, Multer делегирует его обработку Express. Вы можете выводить страницу ошибки [стандартными для express способами](https://expressjs.com/en/guide/error-handling).
+Когда выбрасывается исключение, Multer делегирует его обработку Express. Вы можете выводить страницу ошибки [стандартными для express способами](https://expressjs.com/en/guide/error-handling/).
 
 Если вы хотите отлавливать ошибки конкретно от Multer, вам нужно вызывать собственную middleware для их обработки. Еще, если вы хотите отлавливать [исключительно ошибки Multer](https://github.com/expressjs/multer/blob/main/lib/make-error.js#L1-L9), вы можете использовать класс `MulterError`, который привязан к объекту `multer` (например, `err instanceof multer.MulterError`)
 

--- a/doc/README-tr.md
+++ b/doc/README-tr.md
@@ -68,7 +68,7 @@ const uploadMiddleware = upload.fields([
   { name: "gallery", maxCount: 8 },
 ]);
 app.post("/cool-profile", uploadMiddleware, function (req, res, next) {
-  
+
 // req.files bir nesnedir (String -> Array) ve burada fieldname (alan adı) anahtar, değer ise dosyaların bulunduğu bir dizidir.
 // Örneğin:
 // req.files['avatar'][0] -> File
@@ -313,10 +313,10 @@ function fileFilter(req, file, cb) {
 }
 ```
 
-## Hata Yönetimi 
+## Hata Yönetimi
 
 Bir hatayla karşılaşıldığında, Multer hatayı Express'e devreder.
-[Standart Express yöntemi](http://expressjs.com/guide/error-handling.html) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
+[Standart Express yöntemi](https://expressjs.com/en/guide/error-handling) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
 
 Özellikle Multer'dan gelen hataları yakalamak istiyorsanız,
 orta katman işlevini kendiniz çağırabilirsiniz. Ayrıca, yalnızca [Multer hatalarını](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) yakalamak istiyorsanız, `multer` nesnesine eklenmiş olan `MulterError` sınıfını kullanabilirsiniz (ör. `err instanceof multer.MulterError`).

--- a/doc/README-tr.md
+++ b/doc/README-tr.md
@@ -316,7 +316,7 @@ function fileFilter(req, file, cb) {
 ## Hata Yönetimi
 
 Bir hatayla karşılaşıldığında, Multer hatayı Express'e devreder.
-[Standart Express yöntemi](https://expressjs.com/en/guide/error-handling) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
+[Standart Express yöntemi](https://expressjs.com/en/guide/error-handling/) kullanarak güzel bir hata sayfası görüntüleyebilirsiniz.
 
 Özellikle Multer'dan gelen hataları yakalamak istiyorsanız,
 orta katman işlevini kendiniz çağırabilirsiniz. Ayrıca, yalnızca [Multer hatalarını](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) yakalamak istiyorsanız, `multer` nesnesine eklenmiş olan `MulterError` sınıfını kullanabilirsiniz (ör. `err instanceof multer.MulterError`).

--- a/doc/README-uz.md
+++ b/doc/README-uz.md
@@ -243,7 +243,7 @@ function fileFilter (req, file, cb) {
 
 ## Xatolar bilan ishlash
 
-Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standart express usuli](http://expressjs.com/guide/error-handling.html)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
+Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standart express usuli](https://expressjs.com/en/guide/error-handling)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
 
 Agar siz Multerdan chiqqan xatolarni aniqlamoqchi bo'lsangiz o'zingiz `middleware` funksiya yozishingiz mumkin. Shuningdek, agar siz faqat [Multer xatolarini](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) ushlamoqchi bo'lsangiz, siz `multer` ob'ektiga yozilgan `MulterError` class ni ishlatishingiz mumkin (masalan, `err instanceof multer.MulterError`).
 

--- a/doc/README-uz.md
+++ b/doc/README-uz.md
@@ -243,7 +243,7 @@ function fileFilter (req, file, cb) {
 
 ## Xatolar bilan ishlash
 
-Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standart express usuli](https://expressjs.com/en/guide/error-handling)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
+Xatoga duch kelganda, Multer xatoni Expressga yuboradi. [standart express usuli](https://expressjs.com/en/guide/error-handling/)dan foydalanib xatoni tartibliroq chiqarishingiz mumkin.
 
 Agar siz Multerdan chiqqan xatolarni aniqlamoqchi bo'lsangiz o'zingiz `middleware` funksiya yozishingiz mumkin. Shuningdek, agar siz faqat [Multer xatolarini](https://github.com/expressjs/multer/blob/main/lib/multer-error.js) ushlamoqchi bo'lsangiz, siz `multer` ob'ektiga yozilgan `MulterError` class ni ishlatishingiz mumkin (masalan, `err instanceof multer.MulterError`).
 

--- a/doc/README-vi.md
+++ b/doc/README-vi.md
@@ -261,7 +261,7 @@ function fileFilter(req, file, cb) {
 ## Error handling
 
 Khi một lỗi xảy ra, Multer sẽ gửi lỗi đó cho Express. Bạn có thể hiển thị
-đẹp hơn sử dụng [cách bắt lỗi chuẩn của Express](http://expressjs.com/guide/error-handling.html).
+đẹp hơn sử dụng [cách bắt lỗi chuẩn của Express](https://expressjs.com/en/guide/error-handling).
 
 Nếu bạn muốn bắt các lỗi cụ thể từ Multer, bạn có thể tự gọi hàm trung gian (middleware) này. Ngoài ra, nếu bạn chỉ muốn bắt [lỗi của Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), bạn có thể dùng class `MulterError` được đính kèm với chính object `multer` (vd: `err instanceof multer.MulterError`).
 

--- a/doc/README-vi.md
+++ b/doc/README-vi.md
@@ -261,7 +261,7 @@ function fileFilter(req, file, cb) {
 ## Error handling
 
 Khi một lỗi xảy ra, Multer sẽ gửi lỗi đó cho Express. Bạn có thể hiển thị
-đẹp hơn sử dụng [cách bắt lỗi chuẩn của Express](https://expressjs.com/en/guide/error-handling).
+đẹp hơn sử dụng [cách bắt lỗi chuẩn của Express](https://expressjs.com/en/guide/error-handling/).
 
 Nếu bạn muốn bắt các lỗi cụ thể từ Multer, bạn có thể tự gọi hàm trung gian (middleware) này. Ngoài ra, nếu bạn chỉ muốn bắt [lỗi của Multer](https://github.com/expressjs/multer/blob/main/lib/multer-error.js), bạn có thể dùng class `MulterError` được đính kèm với chính object `multer` (vd: `err instanceof multer.MulterError`).
 

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -234,7 +234,7 @@ function fileFilter (req, file, cb) {
 
 ## 错误处理机制
 
-当遇到一个错误，multer 将会把错误发送给 express。你可以使用一个比较好的错误展示页 ([express标准方式](http://expressjs.com/guide/error-handling.html))。
+当遇到一个错误，multer 将会把错误发送给 express。你可以使用一个比较好的错误展示页 ([express标准方式](https://expressjs.com/zh-cn/guide/error-handling))。
 
 如果你想捕捉 multer 发出的错误，你可以自己调用中间件程序。如果你想捕捉 [Multer 错误](https://github.com/expressjs/multer/blob/main/lib/multer-error.js)，你可以使用 `multer` 对象下的 `MulterError` 类 (即 `err instanceof multer.MulterError`)。
 

--- a/doc/README-zh-cn.md
+++ b/doc/README-zh-cn.md
@@ -234,7 +234,7 @@ function fileFilter (req, file, cb) {
 
 ## 错误处理机制
 
-当遇到一个错误，multer 将会把错误发送给 express。你可以使用一个比较好的错误展示页 ([express标准方式](https://expressjs.com/zh-cn/guide/error-handling))。
+当遇到一个错误，multer 将会把错误发送给 express。你可以使用一个比较好的错误展示页 ([express标准方式](https://expressjs.com/zh-cn/guide/error-handling/))。
 
 如果你想捕捉 multer 发出的错误，你可以自己调用中间件程序。如果你想捕捉 [Multer 错误](https://github.com/expressjs/multer/blob/main/lib/multer-error.js)，你可以使用 `multer` 对象下的 `MulterError` 类 (即 `err instanceof multer.MulterError`)。
 


### PR DESCRIPTION
The links without language in URL are currently broken (https://github.com/expressjs/expressjs.com/issues/2343). Wherever a translated version is available the links point to it.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
