### PR TITLE
fix: allow files at exact fileSize limit

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -20,6 +20,20 @@ function makeMiddleware (setup) {
     var options = setup()
 
     var limits = options.limits
+    var busboyLimits = limits
+
+    if (limits && Object.prototype.hasOwnProperty.call(limits, 'fileSize')) {
+      busboyLimits = {}
+      var key
+      for (key in limits) {
+        busboyLimits[key] = limits[key]
+      }
+
+      if (typeof limits.fileSize === 'number' && isFinite(limits.fileSize)) {
+        busboyLimits.fileSize = limits.fileSize + 1
+      }
+    }
+
     var storage = options.storage
     var fileFilter = options.fileFilter
     var fileStrategy = options.fileStrategy
@@ -126,7 +140,7 @@ function makeMiddleware (setup) {
     try {
       busboy = Busboy({
         headers: req.headers,
-        limits: limits,
+        limits: busboyLimits,
         preservePath: preservePath,
         defParamCharset: defParamCharset
       })

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -66,6 +66,18 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should allow file that is exactly at file size limit', function (done) {
+    var form = new FormData()
+    var parser = multer({ storage: multer.memoryStorage(), limits: { fileSize: 1500 } }).single('small0')
+
+    form.append('small0', Buffer.alloc(1500), 'small0.txt')
+
+    util.submitForm(parser, form, function (err) {
+      assert.ifError(err)
+      done()
+    })
+  })
+
   it('should respect file count limit', function (done) {
     var form = new FormData()
     var parser = withLimits({ files: 1 }, [


### PR DESCRIPTION
## What changed
- Increase configured ileSize limit passed to Busboy by 1 byte only when limits.fileSize is explicitly set.
- This avoids treating an upload exactly equal to limits.fileSize as over-size while preserving the current error for larger uploads.
- Add regression test for exact-boundary acceptance in 	est/error-handling.js.

Fixes #1348 (off-by-one file size limit behavior).