### PR TITLE
docs: use crypto.randomBytes in translated diskStorage examples

### DIFF
--- a/doc/README-fr.md
+++ b/doc/README-fr.md
@@ -198,13 +198,17 @@ où vous gérez les fichiers téléchargés.
 Le moteur de stockage sur disque vous donne un contrôle total sur le stockage des fichiers sur le disque.
 
 ```javascript
+const crypto = require('crypto')
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
-    cb(null, file.fieldname + '-' + uniqueSuffix)
+    crypto.randomBytes(16, function (err, raw) {
+      if (err) return cb(err)
+      cb(null, file.fieldname + '-' + raw.toString('hex'))
+    })
   }
 })
 

--- a/doc/README-tr.md
+++ b/doc/README-tr.md
@@ -216,13 +216,17 @@ Bu işlevi yalnızca, yüklenen dosyaları işlediğiniz rotalarda kullanın.
 Disk depolama motoru, dosyaları diske kaydetme konusunda size tam kontrol sağlar.
 
 ```javascript
+const crypto = require("crypto");
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, "/tmp/my-uploads");
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9);
-    cb(null, file.fieldname + "-" + uniqueSuffix);
+    crypto.randomBytes(16, function (err, raw) {
+      if (err) return cb(err);
+      cb(null, file.fieldname + "-" + raw.toString("hex"));
+    });
   },
 });
 


### PR DESCRIPTION
## Changes
- Replace insecure Math.random() filename snippet with crypto.randomBytes in doc/README-fr.md and doc/README-tr.md.
- This aligns translated docs with secure filename generation guidance and avoids documenting predictable IDs.