### PR TITLE
fix(v3): port CVE-2025-47944 / CVE-2025-47935

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
 
+- Fix [CVE-2025-47935](https://www.cve.org/CVERecord?id=CVE-2025-47935) ([GHSA-44fp-w29j-9vj5](https://github.com/expressjs/multer/security/advisories/GHSA-44fp-w29j-9vj5))
+- Fix [CVE-2025-47944](https://www.cve.org/CVERecord?id=CVE-2025-47944) ([GHSA-4pg4-qvpc-4q3h](https://github.com/expressjs/multer/security/advisories/GHSA-4pg4-qvpc-4q3h))
 - Support node >=18.0.0
 
 ## 3.0.0-alpha.1 - 2025-05-23

--- a/lib/read-body.js
+++ b/lib/read-body.js
@@ -13,7 +13,9 @@ const onFinished = promisify(_onFinished)
 const pipeline = promisify(_pipeline)
 
 function drainStream (stream) {
-  stream.on('readable', stream.read.bind(stream))
+  stream.on('readable', () => {
+    while (stream.read() !== null) { /* drain */ }
+  })
 }
 
 function collectFields (busboy, limits) {
@@ -109,6 +111,9 @@ export default async function readBody (req, limits, fileFilter) {
     busboy.on('fieldsLimit', () => reject(new MulterError('LIMIT_FIELD_COUNT')))
 
     busboy.on('finish', resolve)
+
+    // Fallback when busboy stays silent on a malformed body.
+    req.on('close', () => setImmediate(() => reject(new MulterError('CLIENT_ABORTED'))))
   })
 
   req.pipe(busboy)
@@ -119,6 +124,7 @@ export default async function readBody (req, limits, fileFilter) {
   } catch (err) {
     req.unpipe(busboy)
     drainStream(req)
+    req.resume()
     busboy.removeAllListeners()
 
     // Wait for request to close, finish, or error

--- a/test/express-integration.js
+++ b/test/express-integration.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import assert from 'node:assert'
+import http from 'node:http'
 import { promisify } from 'node:util'
 
 import express from 'express'
@@ -104,5 +105,57 @@ describe('Express Integration', () => {
     assert.strictEqual(errorCalled, 0)
     assert.strictEqual(result.body.toString(), 'SUCCESS')
     assert.strictEqual(result.res.statusCode, 200)
+  })
+
+  // Regression for CVE-2025-47944 / CVE-2025-47935.
+  it('should not crash on malformed request that causes two errors to be emitted by busboy', function (done) {
+    this.timeout(5000)
+
+    const router = new express.Router()
+    router.post('/upload', multer().single('file'), (_, res) => res.status(500).end('Request should not be processed'))
+    router.use((err, _, res, __) => res.status(200).end(err.message))
+
+    app.use('/t3', router)
+
+    const boundary = 'AaB03x'
+    const body = [
+      '--' + boundary,
+      'Content-Disposition: form-data; name="file"; filename="test.txt"',
+      'Content-Type: text/plain',
+      '',
+      '--' + boundary + '--',
+      ''
+    ].join('\r\n')
+
+    let finished = false
+    const finish = (err) => {
+      if (finished) return
+      finished = true
+      clearTimeout(watchdog)
+      done(err)
+    }
+
+    const req = http.request({
+      hostname: 'localhost',
+      port,
+      path: '/t3/upload',
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=' + boundary,
+        'content-length': body.length
+      }
+    }, (res) => {
+      assert.strictEqual(res.statusCode, 200)
+      finish()
+    })
+
+    req.on('error', (err) => finish(err))
+    req.write(body)
+    req.end()
+
+    const watchdog = setTimeout(() => {
+      req.destroy()
+      finish(new Error('Middleware hung on malformed multipart body'))
+    }, 3000)
   })
 })


### PR DESCRIPTION
Backports the malformed-body DoS fix from 2.x (commit 2c8505f) to the v3 branch.

The v3 rewrite introduced a different failure shape than 2.x: when `@fastify/busboy` is fed a malformed multipart body, it emits no events at all (no `file`, no `finish`, no `error`), leaving the middleware awaiting `Promise.all([fields, files, guard])` indefinitely.