### PR TITLE
docs: clarify preservePath behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Each file contains the following information:
 Key | Description | Note
 --- | --- | ---
 `fieldname` | Field name specified in the form |
-`originalname` | Name of the file on the user's computer |
+`originalname` | Name of the file on the user's computer, or the full path when `preservePath: true` |
 `encoding` | Encoding type of the file |
 `mimetype` | Mime type of the file |
 `size` | Size of the file in bytes |
@@ -145,7 +145,7 @@ Key | Description
 `dest` or `storage` | Where to store the files
 `fileFilter` | Function to control which files are accepted
 `limits` | Limits of the uploaded data
-`preservePath` | Keep the full path of files instead of just the base name
+`preservePath` | Keep the full client-supplied path in `file.originalname` instead of just the base name
 `defParamCharset` | Default character set to use for values of part header parameters (e.g. filename) that are not extended parameters (that contain an explicit charset). Default: `'latin1'`
 
 In an average web app, only `dest` might be required, and configured as shown in
@@ -154,6 +154,13 @@ the following example.
 ```javascript
 const upload = multer({ dest: 'uploads/' })
 ```
+
+When `preservePath` is enabled, Multer passes the incoming filename through with
+any path segments provided by the client. This is exposed as `file.originalname`;
+it does not change the destination folder, create directories, or sanitize the
+path for you. Treat `file.originalname` as untrusted input if you use it in a
+custom `filename` or storage engine, and normalize or validate it before writing
+to disk.
 
 If you want more control over your uploads, you'll want to use the `storage`
 option instead of `dest`. Multer ships with storage engines `DiskStorage`

--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ const upload = multer({ dest: 'uploads/' })
 When `preservePath` is enabled, Multer passes the incoming filename through with
 any path segments provided by the client. This is exposed as `file.originalname`;
 it does not change the destination folder, create directories, or sanitize the
-path for you. Treat `file.originalname` as untrusted input if you use it in a
-custom `filename` or storage engine, and normalize or validate it before writing
-to disk.
+path for you. `file.originalname` is always client-supplied and should be treated
+as untrusted; with `preservePath` it additionally contains the path segments the
+client sent. Normalize or validate it before using it in a custom `filename` or
+storage engine.
 
 If you want more control over your uploads, you'll want to use the `storage`
 option instead of `dest`. Multer ships with storage engines `DiskStorage`


### PR DESCRIPTION
Clarifies what `preservePath: true` does for uploaded file metadata.

The README currently says it keeps the full path instead of the base name, but it does not explain where that path appears or that it is client-supplied input. This adds wording that:

- identifies `file.originalname` as the field affected by `preservePath`;
- notes that Multer does not create directories or sanitize the path;
- warns applications to normalize or validate `file.originalname` before using it in a custom filename or storage engine.

Refs #846.

Verification:
- `npm test` (72 passing)
- `npm run lint` with HOME pointed at the task workspace because the sandbox home is read-only
- `git diff --check HEAD~1..HEAD`