### PR TITLE
fix: add .gitattributes to prevent CRLF corruption of test fixtures on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Treat test fixture files as binary (prevent CRLF conversion on Windows)
+test/files/*.dat binary
+test/files/*.jpg binary

--- a/test/functionality.js
+++ b/test/functionality.js
@@ -129,8 +129,8 @@ describe('Functionality', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
       assert.strictEqual(req.files.length, 2)
-      assert.ok(req.files[0].path.indexOf('/testforme-') >= 0)
-      assert.ok(req.files[1].path.indexOf('/testforme-') >= 0)
+      assert.ok(req.files[0].path.indexOf('testforme-') >= 0)
+      assert.ok(req.files[1].path.indexOf('testforme-') >= 0)
       done()
     })
   })


### PR DESCRIPTION
## Problem
On Windows, Git's automatic CRLF line ending conversion corrupts binary 
test fixture files (.dat), causing 12 test failures due to file size 
mismatches (expected 1778 bytes, got 1803 bytes — a difference of 25 bytes 
matching exactly 25 `\r` characters added by Windows).

## Fix
- Added `.gitattributes` marking `test/files/*.dat` and `test/files/*.jpg` 
  as binary to prevent line ending conversion on any OS
- Fixed hardcoded Unix path separator `/testforme-` → `testforme-` in 
  `test/functionality.js` for cross-platform compatibility

## Testing
All 72 tests now pass on Windows.