### PR TITLE
docs: use crypto.randomBytes in DiskStorage filename example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,20 @@ where you are handling the uploaded files.
 The disk storage engine gives you full control on storing files to disk.
 
 ```javascript
+const crypto = require('crypto')
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
-    cb(null, file.fieldname + '-' + uniqueSuffix)
+    // Use crypto.randomBytes for a cryptographically secure unique name.
+    // Math.random() is NOT cryptographically secure and should be avoided
+    // for filenames in web-accessible upload directories.
+    crypto.randomBytes(16, function (err, raw) {
+      if (err) return cb(err)
+      cb(null, file.fieldname + '-' + raw.toString('hex'))
+    })
   }
 })
 


### PR DESCRIPTION
## Summary

Update the README's custom `DiskStorage` filename example to use Node.js `crypto.randomBytes(16)` instead of a timestamp plus `Math.random()`.

Multer's built-in disk storage already uses `crypto.randomBytes(16)` in `storage/disk.js`. Using the same approach in the custom-storage example keeps the documentation aligned with the implementation and avoids presenting `Math.random()` as a source of security-sensitive randomness.

Randomized filenames are not a substitute for authorization or safe upload handling; applications must still control access to stored files.

## Changes

- require Node.js's built-in `crypto` module
- generate a 16-byte random suffix asynchronously
- propagate a `randomBytes` error through Multer's filename callback
- keep the existing field-name prefix and callback-based example style

Fixes #1386

## Validation

- `npm test` — 80 passing
- `npm run lint` — passed
- `node --check` on the complete README example — passed
- runtime probe confirmed the example produces `<fieldname>-` followed by 32 lowercase hexadecimal characters
- `npm audit --omit=dev --audit-level=low` — 0 production vulnerabilities
