### PR TITLE
fix: do not consume maxCount for files skipped by fileFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Files skipped by `fileFilter` no longer count towards `maxCount` ([#1426](https://github.com/expressjs/multer/pull/1426))
 - Accept requests with exactly `limits.parts` parts; `LIMIT_PART_COUNT` now fires only when the limit is exceeded. If you set `parts` one higher to work around this, you can drop the extra one ([#1446](https://github.com/expressjs/multer/pull/1446))
 
 ## 2.3.0

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Accept an array of files, all with the name `fieldname`. Optionally error out if
 more than `maxCount` files are uploaded. The array of files will be stored in
 `req.files`.
 
+Files skipped by `fileFilter` do not count towards `maxCount`. Use
+`limits.files` to bound how many files are read from a request.
+
 #### `.fields(fields)`
 
 Accept a mix of files, specified by `fields`. An object with arrays of files

--- a/index.js
+++ b/index.js
@@ -46,8 +46,13 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
         return cb(new MulterError('LIMIT_UNEXPECTED_FILE', file.fieldname, file.originalname))
       }
 
-      filesLeft[file.fieldname] -= 1
-      fileFilter(req, file, cb)
+      // Only count the file against the field's maxCount once the user's
+      // fileFilter has accepted it. A file skipped via cb(null, false) is
+      // never stored, so it must not consume a slot (see #1419).
+      fileFilter(req, file, function (err, includeFile) {
+        if (!err && includeFile) filesLeft[file.fieldname] -= 1
+        cb(err, includeFile)
+      })
     }
 
     return {

--- a/test/file-filter.js
+++ b/test/file-filter.js
@@ -18,6 +18,10 @@ function reportFakeError (req, file, cb) {
   cb(new Error('Fake error'))
 }
 
+function skipByOriginalName (req, file, cb) {
+  cb(null, file.originalname !== 'tiny0.dat')
+}
+
 describe('File Filter', function () {
   it('should skip some files', function (done) {
     var form = new FormData()
@@ -37,6 +41,24 @@ describe('File Filter', function () {
       assert.strictEqual(req.files.butme[0].originalname, 'tiny1.dat')
       assert.strictEqual(req.files.butme[0].size, 7)
       assert.strictEqual(req.files.butme[0].buffer.length, 7)
+      done()
+    })
+  })
+
+  it('should not consume maxCount for files skipped by fileFilter (#1419)', function (done) {
+    var form = new FormData()
+    var upload = withFilter(skipByOriginalName)
+    var parser = upload.array('docs', 1)
+
+    // Two files on the same field: the first is skipped by the filter, the
+    // second accepted. The skipped file must not consume the single slot.
+    form.append('docs', util.file('tiny0.dat'))
+    form.append('docs', util.file('tiny1.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.files.length, 1)
+      assert.strictEqual(req.files[0].originalname, 'tiny1.dat')
       done()
     })
   })


### PR DESCRIPTION
## Description

`wrappedFileFilter` decrements the field's remaining-count **before** the user's `fileFilter` runs:

```js
filesLeft[file.fieldname] -= 1
fileFilter(req, file, cb)
```

So a file the user skips with `cb(null, false)` still consumes a slot. With `.array('docs', 1)`, uploading a skipped file followed by an accepted file on the same field makes the second file fail with `LIMIT_UNEXPECTED_FILE` — even though **zero** files were stored. Per the README, `cb(null, false)` means the file is silently skipped (never added to `req.files`), so it must not count against `maxCount`. Fixes #1419.

## Fix

Move the decrement inside the `fileFilter` callback and only decrement when the file is actually accepted:

```js
fileFilter(req, file, function (err, includeFile) {
  if (!err && includeFile) filesLeft[file.fieldname] -= 1
  cb(err, includeFile)
})
```

This routes all callers (`.single` / `.array` / `.fields`) through one guard. Truly unexpected fields and accepted files beyond `maxCount` still error as before.

## Test

Added a regression test in `test/file-filter.js`: a `.array('docs', 1)` upload where the filter skips the first same-field file and accepts the second — asserts exactly one file (`tiny1.dat`) is stored with no error. The test fails on `main` without the fix (`LIMIT_UNEXPECTED_FILE`) and passes with it; existing fileFilter tests remain green.