### PR TITLE
fix: prevent process crash when fileFilter calls its callback more than once

### DIFF
--- a/lib/file-appender.js
+++ b/lib/file-appender.js
@@ -42,14 +42,13 @@ FileAppender.prototype.removePlaceholder = function (placeholder) {
     case 'NONE': break
     case 'VALUE': break
     case 'ARRAY': arrayRemove(this.req.files, placeholder); break
-    case 'OBJECT':
-      if (!this.req.files[placeholder.fieldname]) break
-      if (this.req.files[placeholder.fieldname].length === 1) {
-        delete this.req.files[placeholder.fieldname]
-      } else {
-        arrayRemove(this.req.files[placeholder.fieldname], placeholder)
-      }
+    case 'OBJECT': {
+      var files = this.req.files[placeholder.fieldname]
+      if (!files) break
+      arrayRemove(files, placeholder)
+      if (files.length === 0) delete this.req.files[placeholder.fieldname]
       break
+    }
   }
 }
 

--- a/lib/file-appender.js
+++ b/lib/file-appender.js
@@ -43,6 +43,7 @@ FileAppender.prototype.removePlaceholder = function (placeholder) {
     case 'VALUE': break
     case 'ARRAY': arrayRemove(this.req.files, placeholder); break
     case 'OBJECT':
+      if (!this.req.files[placeholder.fieldname]) break
       if (this.req.files[placeholder.fieldname].length === 1) {
         delete this.req.files[placeholder.fieldname]
       } else {

--- a/test/file-filter.js
+++ b/test/file-filter.js
@@ -53,4 +53,27 @@ describe('File Filter', function () {
       done()
     })
   })
+
+  it('should not crash when fileFilter invokes the callback more than once', function (done) {
+    function rejectThenError (req, file, cb) {
+      setImmediate(function () {
+        cb(null, false)
+        cb(new Error('Fake error'))
+      })
+    }
+
+    var form = new FormData()
+    var upload = withFilter(rejectThenError)
+    var parser = upload.fields([
+      { name: 'logo', maxCount: 1 },
+      { name: 'banner', maxCount: 1 }
+    ])
+
+    form.append('logo', util.file('tiny0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ok(err)
+      done()
+    })
+  })
 })

--- a/test/file-filter.js
+++ b/test/file-filter.js
@@ -76,4 +76,33 @@ describe('File Filter', function () {
       done()
     })
   })
+
+  it('should keep an accepted file when a sibling triggers a duplicate reject', function (done) {
+    var calls = 0
+    function acceptFirstDoubleRejectSecond (req, file, cb) {
+      calls++
+      if (calls === 1) return cb(null, true)
+      setImmediate(function () {
+        cb(null, false)
+        cb(null, false)
+      })
+    }
+
+    var form = new FormData()
+    var upload = withFilter(acceptFirstDoubleRejectSecond)
+    var parser = upload.fields([
+      { name: 'docs', maxCount: 2 }
+    ])
+
+    form.append('docs', util.file('tiny0.dat'))
+    form.append('docs', util.file('tiny1.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.ok(req.files.docs, 'the accepted file must not be dropped')
+      assert.strictEqual(req.files.docs.length, 1)
+      assert.strictEqual(req.files.docs[0].originalname, 'tiny0.dat')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Fixes #950.

With `upload.fields()`, if a `fileFilter` invokes its callback more than once and does so asynchronously, Multer crashes the whole Node process with an uncaught exception:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at FileAppender.removePlaceholder (lib/file-appender.js)
```

A placeholder is inserted synchronously when the file event fires, then removed asynchronously from the `fileFilter` callback. When the callback runs twice, `removePlaceholder` runs twice for the same field: the first call sees length 1 and deletes `req.files[fieldname]`; the second call reads `.length` of the now-missing entry and throws on a later tick, where there is no surrounding try/catch, so the process dies. This has been reported repeatedly (#950, #1093, #1205).

Only the `OBJECT` strategy (`upload.fields()`) is affected; the `ARRAY` strategy (`upload.array()`) already tolerates a double callback because `arrayRemove` no-ops on a missing entry.

## Fix

Break out of the `OBJECT` branch when the field entry is already gone, matching the null-safety the `ARRAY` branch already has. The single-callback path and behavior are unchanged.

## Testing

Added a test to `test/file-filter.js`: a `.fields()` parser whose `fileFilter` calls the callback twice via `setImmediate` (the asynchronous case). It crashes the process on the current code and passes with the fix. Full suite stays green (81 passing).
