### PR TITLE
docs: add Express Router upload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ app.post('/cool-profile', uploadMiddleware, function (req, res, next) {
 })
 ```
 
+The same upload middleware can be used with an `express.Router()` instance:
+
+```javascript
+const express = require('express')
+const multer  = require('multer')
+
+const router = express.Router()
+const upload = multer({ dest: 'uploads/' })
+
+router.post('/uploadFiles', upload.array('documents'), function (req, res, next) {
+  // req.files is array of `documents` files
+  // req.body will contain the text fields, if there were any
+  res.sendStatus(204)
+})
+
+module.exports = router
+```
+
 In case you need to handle a text-only multipart form, you should use the `.none()` method:
 
 ```javascript


### PR DESCRIPTION
## Summary

Adds a concise README example showing Multer middleware used with an `express.Router()` route.

This addresses the confusion raised in #596 by showing that the same `upload.array(...)` middleware pattern used on `app.post(...)` can be mounted directly on a router route.

Fixes #596.

## Verification

- `npm test` (80 passing)
- `npm run lint`
- `git diff --check`