### PR TITLE
docs: correct fieldNameSize default in limits table

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The following integer values are available:
 
 Key | Description | Default
 --- | --- | ---
-`fieldNameSize` | Max field name size | 100 bytes
+`fieldNameSize` | Max field name size | Infinity
 `fieldSize` | Max field value size (in bytes) | 1MB
 `fields` | Max number of non-file fields | Infinity
 `fileSize` | For multipart forms, the max file size (in bytes) | Infinity


### PR DESCRIPTION
`README.md:277` documents `fieldNameSize` as defaulting to `100 bytes`, but the runtime does not enforce that default. `lib/make-middleware.js` only checks `fieldNameSize` when the developer explicitly passes it via `limits`, gated behind `Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')`.

Correcting the table to say `Infinity` matches the shape of adjacent unenforced-limit rows (`fields`, `parts`, `fieldNestingDepth`) and reflects actual multer runtime behavior. Developers who want a bound must set `limits.fieldNameSize` explicitly.

A separate PR against `v3` will add a real enforced default as a breaking change for the next major release.