### PR TITLE
feat!: enforce default fieldNestingDepth of 32

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Key | Description | Default
 `fieldNameSize` | Max number of bytes per field name | `'100B'`
 `fieldSize` | Max number of bytes per field value | `'8KB'`
 `fields` | Max number of fields per request | `1000`
-`fieldNestingDepth` | Max number of nesting levels for field names (e.g. `a[b][c]` has 2 levels) | Infinity
+`fieldNestingDepth` | Max number of nesting levels for field names (e.g. `a[b][c]` has 2 levels) | `32`
 `fileSize` | Max number of bytes per file | `'8MB'`
 `files` | Max number of files per request | `10`
 `headerPairs` | Max number of header key-value pairs | `2000` (same as Node's http)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class Multer {
       fieldNameSize: parseLimit(options.limits || {}, 'fieldNameSize', '100B'),
       fieldSize: parseLimit(options.limits || {}, 'fieldSize', '8KB'),
       fields: parseLimit(options.limits || {}, 'fields', 1000),
-      fieldNestingDepth: (options.limits || {}).fieldNestingDepth ?? Infinity,
+      fieldNestingDepth: parseLimit(options.limits || {}, 'fieldNestingDepth', 32),
       fileSize: parseLimit(options.limits || {}, 'fileSize', '8MB'),
       files: parseLimit(options.limits || {}, 'files', 10),
       headerPairs: parseLimit(options.limits || {}, 'headerPairs', 2000)

--- a/test/field-nesting-depth.js
+++ b/test/field-nesting-depth.js
@@ -37,8 +37,17 @@ describe('Field name nesting depth', () => {
     assert.strictEqual(req.body.a[0][1][2], 'value')
   })
 
-  it('should allow unlimited nesting by default', async () => {
+  it('should reject field names exceeding the default fieldNestingDepth', async () => {
     const parser = multer({ limits: { fieldNameSize: '10KB' } }).none()
+    const form = new FormData()
+
+    form.append('a' + '[0]'.repeat(33), 'value')
+
+    await assert.rejects(util.submitForm(parser, form), (err) => err.code === 'LIMIT_FIELD_NESTING')
+  })
+
+  it('should allow deep nesting when opted in to a higher limit', async () => {
+    const parser = multer({ limits: { fieldNameSize: '10KB', fieldNestingDepth: 1000 } }).none()
     const form = new FormData()
 
     form.append('a' + '[0]'.repeat(100), 'value')


### PR DESCRIPTION
The v3 constructor already enforces default values for `fieldNameSize`, `fieldSize`, `fields`, `fileSize`, `files`, and `headerPairs`. `fieldNestingDepth` was the last documented limit without an enforced default (gated by `?? Infinity` in the constructor), leaving deeply-nested field names as the one unbounded per-field allocation path.

This adds a default of `32`, matching the shape of the other limits:

- Well above legitimate form usage (typically 3-5 levels of nesting).
- Small enough to bound the per-bracket `append-field` allocation cost.
- Applications that need more can opt in with `limits.fieldNestingDepth`.

The existing "should allow unlimited nesting by default" test is replaced with two tests: one asserting the default is enforced (33 brackets rejects), and one asserting explicit opt-in to a higher limit still works.

**Breaking change** for next major. Consumers relying on unbounded nesting must set `limits.fieldNestingDepth` explicitly.