### PR TITLE
deps: update type-is from ^1.6.18 to ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "append-field": "^1.0.0",
     "busboy": "^1.6.0",
     "concat-stream": "^2.0.0",
-    "type-is": "^1.6.18"
+    "type-is": "^2.1.0"
   },
   "devDependencies": {
     "deep-equal": "^2.0.3",


### PR DESCRIPTION
## Summary

Upgrade `type-is` runtime dependency from ^1.6.18 to ^2.1.0.

## Motivation

`type-is` v2 upgrades the content-type detection stack (content-type v2, media-typer v1.1, mime-types v3). The API is backward-compatible.

## Testing

- `npm install` succeeds
- `npm test` passes: **80/80** ✅
- No source code changes required

## Changes

- `package.json`: `"type-is": "^1.6.18"` → `"type-is": "^2.1.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)