### PR TITLE
docs: updated README's note with a note blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Multer is a node.js middleware for handling `multipart/form-data`, which is primarily used for uploading files. It is written
 on top of [busboy](https://github.com/mscdex/busboy) for maximum efficiency.
 
-**NOTE**: Multer will not process any form which is not multipart (`multipart/form-data`).
+> [!NOTE]  
+> Multer will not process any form which is not multipart (`multipart/form-data`).
 
 ## Translations
 


### PR DESCRIPTION
Updated README's note with a note blockquote. This change makes the note more readable and harder to miss (don't ask me how I know).

The README goes from this:

<img width="939" height="365" alt="image" src="https://github.com/user-attachments/assets/dc5f09d1-c9df-4408-87a6-127e866fe118" />

to this:

<img width="966" height="351" alt="image" src="https://github.com/user-attachments/assets/dc8d87c2-fc45-45a9-a069-30e5ed67daae" />


<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
