### PR TITLE
docs: use crypto.randomBytes in diskStorage README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,17 @@ where you are handling the uploaded files.
 The disk storage engine gives you full control on storing files to disk.
 
 ```javascript
+const crypto = require('crypto')
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, '/tmp/my-uploads')
   },
   filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9)
-    cb(null, file.fieldname + '-' + uniqueSuffix)
+    crypto.randomBytes(16, function (err, raw) {
+      if (err) return cb(err)
+      cb(null, file.fieldname + '-' + raw.toString('hex'))
+    })
   }
 })
 


### PR DESCRIPTION
## Summary
- Update the `diskStorage` custom `filename` example to use `crypto.randomBytes` instead of `Math.random()`.
- Align the README example with multer's default secure filename generator in `storage/disk.js`.

Fixes #1386

## Test plan
- [ ] Confirm the README DiskStorage example renders correctly
- [ ] Confirm the example matches the callback style used by `crypto.randomBytes` in `storage/disk.js`