### PR TITLE
feat: add an opt-in fieldArrayIndexLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Key | Description | Default
 `parts` | For multipart forms, the max number of parts (fields + files) | Infinity
 `headerPairs` | For multipart forms, the max number of header key=>value pairs to parse | 2000
 `fieldNestingDepth` | Max number of nesting levels for field names (e.g. `a[b][c]` has 2 levels) | Infinity
+`fieldArrayIndexLimit` | Max numeric array index accepted inside a field name (e.g. `a[3]` uses index 3) | Infinity
 
 Specifying the limits can help protect your site against denial of service (DoS) attacks.
 
@@ -316,6 +317,7 @@ Specifying the [limits](#limits) can help protect your site against denial of se
 - `files` -- set to the maximum number of files per request
 - `fields` -- set to the maximum number of text fields per request
 - `fieldNestingDepth` -- set to the minimum depth your field names require (e.g. `3` for `a[b][c]`)
+- `fieldArrayIndexLimit` -- set to the largest array index your field names require (e.g. `100` for `a[99]`)
 
 ## Error handling
 

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -7,6 +7,23 @@ var MulterError = require('./multer-error')
 var FileAppender = require('./file-appender')
 var removeUploadedFiles = require('./remove-uploaded-files')
 
+// append-field turns a bracket group whose contents are all digits into an
+// array index, so `a[3]` produces an array of length 4. The index itself is
+// unbounded, which means a single field name can materialize a sparse array
+// with a very large length. That costs append-field almost nothing, but it is
+// the application that pays when it later iterates or serializes req.body, and
+// until now there was no limit to opt into.
+function exceedsArrayIndexLimit (fieldname, limit) {
+  var pattern = /\[(\d+)\]/g
+  var match
+
+  while ((match = pattern.exec(fieldname)) !== null) {
+    if (Number(match[1]) > limit) return true
+  }
+
+  return false
+}
+
 function drainStream (stream) {
   stream.on('readable', () => {
     while (stream.read() !== null) {}
@@ -155,6 +172,12 @@ function makeMiddleware (setup) {
 
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNestingDepth')) {
         if (fieldname.split('[').length - 1 > limits.fieldNestingDepth) return abortWithCode('LIMIT_FIELD_NESTING', fieldname)
+      }
+
+      if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldArrayIndexLimit')) {
+        if (exceedsArrayIndexLimit(fieldname, limits.fieldArrayIndexLimit)) {
+          return abortWithCode('LIMIT_FIELD_ARRAY_INDEX', fieldname)
+        }
       }
 
       appendField(req.body, fieldname, value)

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -18,7 +18,7 @@ function exceedsArrayIndexLimit (fieldname, limit) {
   // Only field names append-field parses as a bracket path build an array;
   // names it stores as a literal key (e.g. a[6]suffix, [6]) never do, so they
   // must not be rejected by the index limit.
-  if (!/^[^[]+(?:\[\d+\]|\[[^\]]+\])*(?:\[\])?$/.test(fieldname)) return false
+  if (!/^[^[]+(?:\[[^\]]+\])*(?:\[\])?$/.test(fieldname)) return false
 
   var pattern = /\[(\d+)\]/g
   var match

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -15,6 +15,11 @@ var removeUploadedFiles = require('./remove-uploaded-files')
 // the application that pays when it later iterates or serializes req.body, and
 // until now there was no limit to opt into.
 function exceedsArrayIndexLimit (fieldname, limit) {
+  // Only field names append-field parses as a bracket path build an array;
+  // names it stores as a literal key (e.g. a[6]suffix, [6]) never do, so they
+  // must not be rejected by the index limit.
+  if (!/^[^[]+(?:\[\d+\]|\[[^\]]+\])*(?:\[\])?$/.test(fieldname)) return false
+
   var pattern = /\[(\d+)\]/g
   var match
 

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -9,7 +9,8 @@ var errorMessages = {
   LIMIT_FIELD_COUNT: 'Too many fields',
   LIMIT_UNEXPECTED_FILE: 'Unexpected field',
   MISSING_FIELD_NAME: 'Field name missing',
-  LIMIT_FIELD_NESTING: 'Field name nesting too deep'
+  LIMIT_FIELD_NESTING: 'Field name nesting too deep',
+  LIMIT_FIELD_ARRAY_INDEX: 'Field name array index too large'
 }
 
 function MulterError (code, field) {

--- a/test/array-index-limit.js
+++ b/test/array-index-limit.js
@@ -7,8 +7,6 @@ var multer = require('../')
 var FormData = require('form-data')
 
 describe('Field name array index limit', function () {
-  // @see https://github.com/expressjs/multer/security/advisories/GHSA-cf2x-4m44-rv66
-
   it('should reject an array index above fieldArrayIndexLimit', function (done) {
     var parser = multer({ limits: { fieldArrayIndexLimit: 1000 } }).none()
     var form = new FormData()
@@ -49,6 +47,19 @@ describe('Field name array index limit', function () {
     })
   })
 
+  it('should reject an array index one above the limit', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 5 } }).none()
+    var form = new FormData()
+
+    form.append('a[6]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ok(err, 'should have returned an error')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_ARRAY_INDEX')
+      done()
+    })
+  })
+
   it('should bound a numeric key even when the limit is zero', function (done) {
     var parser = multer({ limits: { fieldArrayIndexLimit: 0 } }).none()
     var form = new FormData()
@@ -71,6 +82,34 @@ describe('Field name array index limit', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
       assert.strictEqual(req.body.a['99999999x'], 'value')
+      done()
+    })
+  })
+
+  it('should allow bracketed digits in a name stored as a literal key', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 5 } }).none()
+    var form = new FormData()
+
+    // Trailing text makes append-field store the whole name as a literal key
+    // rather than an array path, so no array is built and the limit must not fire.
+    form.append('a[6]suffix', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body['a[6]suffix'], 'value')
+      done()
+    })
+  })
+
+  it('should allow a nested array index within the limit', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 100 } }).none()
+    var form = new FormData()
+
+    form.append('a[b][3]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.a.b[3], 'value')
       done()
     })
   })

--- a/test/array-index-limit.js
+++ b/test/array-index-limit.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+
+describe('Field name array index limit', function () {
+  // @see https://github.com/expressjs/multer/security/advisories/GHSA-cf2x-4m44-rv66
+
+  it('should reject an array index above fieldArrayIndexLimit', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 1000 } }).none()
+    var form = new FormData()
+
+    form.append('a[4294967294]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ok(err, 'should have returned an error')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_ARRAY_INDEX')
+      assert.strictEqual(err.field, 'a[4294967294]')
+      done()
+    })
+  })
+
+  it('should reject an oversized index nested behind object keys', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 10 } }).none()
+    var form = new FormData()
+
+    form.append('a[b][c][99999]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ok(err, 'should have returned an error')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_ARRAY_INDEX')
+      done()
+    })
+  })
+
+  it('should allow an index at exactly the limit', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 5 } }).none()
+    var form = new FormData()
+
+    form.append('a[5]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.a.length, 6)
+      done()
+    })
+  })
+
+  it('should bound a numeric key even when the limit is zero', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 0 } }).none()
+    var form = new FormData()
+
+    form.append('a[99999999]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ok(err, 'a numeric key should still be bounded at zero')
+      assert.strictEqual(err.code, 'LIMIT_FIELD_ARRAY_INDEX')
+      done()
+    })
+  })
+
+  it('should leave object keys alone', function (done) {
+    var parser = multer({ limits: { fieldArrayIndexLimit: 0 } }).none()
+    var form = new FormData()
+
+    form.append('a[99999999x]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.a['99999999x'], 'value')
+      done()
+    })
+  })
+
+  it('should be unbounded when the limit is not set', function (done) {
+    var parser = multer({ limits: {} }).none()
+    var form = new FormData()
+
+    form.append('a[4294967294]', 'value')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.a.length, 4294967295)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Adds an opt-in `limits.fieldArrayIndexLimit` that bounds the numeric index allowed inside a bracket field name, complementing the existing `fieldNestingDepth` limit.

`fieldNestingDepth` counts bracket groups, not the number inside them, so `a[1000000]` is one level and passes. `append-field` reads an all-digit bracket group as an array index, and the resulting array carries that length. Applications that want to bound this can now opt in.

## The change

A new `limits.fieldArrayIndexLimit` checked next to the existing `fieldNestingDepth` check, plus a `LIMIT_FIELD_ARRAY_INDEX` error code. Only bracket groups that are entirely digits count, so `a[99999999x]` stays an object key and is untouched. It is opt-in and defaults to unbounded, so with the limit unset behavior is unchanged (there is a test asserting that).

## Tests

`test/array-index-limit.js` covers rejection above the limit, rejection nested behind object keys, acceptance exactly at the limit, a numeric key bounded at a limit of zero, object keys left alone, field names stored as literal keys, and unbounded when unset.

## Notes

The name `fieldArrayIndexLimit` follows multer's `field*` convention. Whether a future major enforces a default, and what value, is a separate call.
