### PR TITLE
chore(deps): bump GitHub Actions and dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           node-version: "26"
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
@@ -146,7 +146,7 @@ jobs:
         fi
 
     - name: Collect code coverage
-      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # master
+      uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
       if: steps.list_env.outputs.nyc != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload code coverage
-      uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # master
+      uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -61,6 +61,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:javascript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -68,7 +68,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif
           

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "type-is": "^1.6.18"
   },
   "devDependencies": {
-    "deep-equal": "^2.0.3",
-    "express": "^4.21.2",
-    "form-data": "^4.0.2",
+    "deep-equal": "^2.2.3",
+    "express": "^4.22.2",
+    "form-data": "^4.0.6",
     "fs-temp": "^1.2.1",
-    "mocha": "^11.5.0",
+    "mocha": "^11.7.6",
     "nyc": "^15.1.0",
-    "rimraf": "^2.4.1",
-    "standard": "^14.3.3",
+    "rimraf": "^2.7.1",
+    "standard": "^14.3.4",
     "testdata-w3c-json-form": "^1.0.0"
   },
   "engines": {


### PR DESCRIPTION
Bumps all GitHub Action pins to the SHA of their latest release, and all package dependencies to the latest version within their current major (no breaking changes).

## GitHub Actions

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6.0.3 | v7.0.1 |
| `coverallsapp/github-action` | master (unversioned pin) | v2.3.8 |
| `github/codeql-action/*` | v4.36.1 | v4.37.4 |
| `ossf/scorecard-action` | v2.4.3 | v2.4.4 |
| `actions/upload-artifact` | v7.0.1 | unchanged (latest) |

All actions remain pinned by commit SHA with the version in a trailing comment.

## Dev dependencies

| Package | Before | After |
|---|---|---|
| `deep-equal` | ^2.0.3 | ^2.2.3 |
| `express` | ^4.21.2 | ^4.22.2 |
| `form-data` | ^4.0.2 | ^4.0.6 |
| `mocha` | ^11.5.0 | ^11.7.6 |
| `rimraf` | ^2.4.1 | ^2.7.1 |
| `standard` | ^14.3.3 | ^14.3.4 |

Runtime dependencies (`append-field`, `busboy`, `concat-stream`, `type-is`) are already at the latest version within their current major.

Verified locally: `npm install`, `npm test` (80 passing), and `npm run lint` all pass.

Fixes #1444