### PR TITLE
fix: allow exactly limits.parts parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Accept requests with exactly `limits.parts` parts; `LIMIT_PART_COUNT` now fires only when the limit is exceeded. If you set `parts` one higher to work around this, you can drop the extra one ([#1446](https://github.com/expressjs/multer/pull/1446))
+
 ## 2.3.0
 
 - Fix [CVE-2026-77078](https://www.cve.org/CVERecord?id=CVE-2026-77078) ([GHSA-wc9g-mqfw-jrwm](https://github.com/expressjs/multer/security/advisories/GHSA-wc9g-mqfw-jrwm))

--- a/README.md
+++ b/README.md
@@ -278,10 +278,6 @@ Key | Description | Default
 `fieldNestingDepth` | Max number of nesting levels for field names (e.g. `a[b][c]` has 2 levels) | Infinity
 `fieldArrayIndexLimit` | Max numeric array index accepted inside a field name (e.g. `a[3]` uses index 3) | Infinity
 
-The `parts` limit is triggered when busboy reaches the configured number of
-parts, not only after that number is exceeded. If you want to allow an exact
-number of fields and files, set `parts` to at least one more than that total.
-
 Specifying the limits can help protect your site against denial of service (DoS) attacks.
 
 ### `fileFilter`

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -72,7 +72,12 @@ function makeMiddleware (setup) {
     var limits = options.limits
     var busboyLimits = limits
 
-    if (limits && Object.prototype.hasOwnProperty.call(limits, 'fileSize')) {
+    // busboy fires 'limit' when the file size reaches limits.fileSize and
+    // 'partsLimit' when the part count reaches limits.parts. Multer treats
+    // both as "max allowed", so pass one more to busboy and let it fire only
+    // once the limit is actually exceeded.
+    if (limits && (Object.prototype.hasOwnProperty.call(limits, 'fileSize') ||
+      Object.prototype.hasOwnProperty.call(limits, 'parts'))) {
       busboyLimits = {}
       var key
       for (key in limits) {
@@ -81,6 +86,10 @@ function makeMiddleware (setup) {
 
       if (typeof limits.fileSize === 'number' && isFinite(limits.fileSize)) {
         busboyLimits.fileSize = limits.fileSize + 1
+      }
+
+      if (typeof limits.parts === 'number' && isFinite(limits.parts)) {
+        busboyLimits.parts = limits.parts + 1
       }
     }
 

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -39,6 +39,39 @@ describe('Error Handling', function () {
     })
   })
 
+  it('should allow exactly the configured number of parts', function (done) {
+    var form = new FormData()
+    var parser = withLimits({ parts: 2 }, [
+      { name: 'small0', maxCount: 1 }
+    ])
+
+    form.append('field0', 'value')
+    form.append('small0', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.field0, 'value')
+      assert.strictEqual(req.files.small0[0].originalname, 'small0.dat')
+      done()
+    })
+  })
+
+  it('should reject one part over the parts limit', function (done) {
+    var form = new FormData()
+    var parser = withLimits({ parts: 2 }, [
+      { name: 'small0', maxCount: 1 }
+    ])
+
+    form.append('field0', 'value')
+    form.append('field1', 'value')
+    form.append('small0', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.strictEqual(err.code, 'LIMIT_PART_COUNT')
+      done()
+    })
+  })
+
   it('should respect parts limit', function (done) {
     var form = new FormData()
     var parser = withLimits({ parts: 1 }, [


### PR DESCRIPTION
busboy emits `partsLimit` as soon as the part count reaches `limits.parts`, so a request with exactly the allowed number of parts was rejected with `LIMIT_PART_COUNT`. This passes `parts + 1` to busboy, the same way `fileSize` is handled since #1407, so the error fires only when the limit is exceeded; busboy still stops parsing at that point. The README workaround from #1430 is removed since it no longer applies.

Rebased onto `main` as a single commit; tests cover exactly-at-limit (accepted) and one-over (rejected).

Closes #1418