### PR TITLE
fix: fallback to error code when no message mapping exists

### DIFF
--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -15,7 +15,7 @@ var errorMessages = {
 function MulterError (code, field) {
   Error.captureStackTrace(this, this.constructor)
   this.name = this.constructor.name
-  this.message = errorMessages[code]
+  this.message = errorMessages[code] || code
   this.code = code
   if (field) this.field = field
 }

--- a/lib/multer-error.js
+++ b/lib/multer-error.js
@@ -15,7 +15,7 @@ var errorMessages = {
 function MulterError (code, field) {
   Error.captureStackTrace(this, this.constructor)
   this.name = this.constructor.name
-  this.message = errorMessages[code] || code
+  this.message = errorMessages[code] || `Unknown error: ${code}`
   this.code = code
   if (field) this.field = field
 }

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -11,19 +11,16 @@ var FormData = require('form-data')
 var http = require('http')
 var net = require('net')
 
-function withLimits(limits, fields) {
+function withLimits (limits, fields) {
   var storage = multer.memoryStorage()
   return multer({ storage: storage, limits: limits }).fields(fields)
 }
 
 describe('Error Handling', function () {
-
-
   it('should use a fallback message when the code is not mapped', function () {
     var err = new MulterError('SOME_NEW_CODE')
     assert.strictEqual(err.message, 'Unknown error: SOME_NEW_CODE')
   })
-
 
   it('should be an instance of both `Error` and `MulterError` classes in case of the Multer\'s error', function (done) {
     var form = new FormData()
@@ -202,7 +199,7 @@ describe('Error Handling', function () {
   it('should report errors from storage engines', function (done) {
     var storage = multer.memoryStorage()
 
-    storage._removeFile = function _removeFile(req, file, cb) {
+    storage._removeFile = function _removeFile (req, file, cb) {
       var err = new Error('Test error')
       err.code = 'TEST'
       cb(err)
@@ -332,7 +329,7 @@ describe('Error Handling', function () {
         })
       }, 8000)
 
-      function finish(err) {
+      function finish (err) {
         if (finished) return
         finished = true
         clearTimeout(timeout)
@@ -341,7 +338,7 @@ describe('Error Handling', function () {
         })
       }
 
-      function writeChunk() {
+      function writeChunk () {
         if (sentChunks >= totalChunks) {
           sock.write(footer)
           return
@@ -456,7 +453,7 @@ describe('Error Handling', function () {
       uploadedFiles.push({ fieldname: 'file', originalname: 'f.dat', buffer: Buffer.alloc(0) })
     }
 
-    function syncRemove(file, cb) {
+    function syncRemove (file, cb) {
       delete file.buffer
       cb(null)
     }

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 var assert = require('assert')
-
+var MulterError = require('../lib/multer-error')
 var os = require('os')
 var util = require('./_util')
 var multer = require('../')
@@ -11,12 +11,20 @@ var FormData = require('form-data')
 var http = require('http')
 var net = require('net')
 
-function withLimits (limits, fields) {
+function withLimits(limits, fields) {
   var storage = multer.memoryStorage()
   return multer({ storage: storage, limits: limits }).fields(fields)
 }
 
 describe('Error Handling', function () {
+
+
+  it('should use a fallback message when the code is not mapped', function () {
+    var err = new MulterError('SOME_NEW_CODE')
+    assert.strictEqual(err.message, 'Unknown error: SOME_NEW_CODE')
+  })
+
+
   it('should be an instance of both `Error` and `MulterError` classes in case of the Multer\'s error', function (done) {
     var form = new FormData()
     var storage = multer.diskStorage({ destination: os.tmpdir() })
@@ -194,7 +202,7 @@ describe('Error Handling', function () {
   it('should report errors from storage engines', function (done) {
     var storage = multer.memoryStorage()
 
-    storage._removeFile = function _removeFile (req, file, cb) {
+    storage._removeFile = function _removeFile(req, file, cb) {
       var err = new Error('Test error')
       err.code = 'TEST'
       cb(err)
@@ -324,7 +332,7 @@ describe('Error Handling', function () {
         })
       }, 8000)
 
-      function finish (err) {
+      function finish(err) {
         if (finished) return
         finished = true
         clearTimeout(timeout)
@@ -333,7 +341,7 @@ describe('Error Handling', function () {
         })
       }
 
-      function writeChunk () {
+      function writeChunk() {
         if (sentChunks >= totalChunks) {
           sock.write(footer)
           return
@@ -429,7 +437,7 @@ describe('Error Handling', function () {
         }, 50)
       })
 
-      sock.on('error', function () {})
+      sock.on('error', function () { })
     })
   })
 
@@ -448,7 +456,7 @@ describe('Error Handling', function () {
       uploadedFiles.push({ fieldname: 'file', originalname: 'f.dat', buffer: Buffer.alloc(0) })
     }
 
-    function syncRemove (file, cb) {
+    function syncRemove(file, cb) {
       delete file.buffer
       cb(null)
     }


### PR DESCRIPTION
Closes #659

Currently `errorMessages[code]` returns `undefined` if the code isn't recognized, so `this.message` silently becomes `undefined` with no useful information.

This adds a fallback so the code itself is used as the message when there's no mapping:

this.message = errorMessages[code] || code

Small, safe first step — happy to follow up with tests or explore a fuller custom-message fix if maintainers think that's worth pursuing.