### PR TITLE
fix(test): use path.sep for cross-platform path assertions

### DIFF
--- a/test/functionality.js
+++ b/test/functionality.js
@@ -2,6 +2,8 @@
 
 var assert = require('assert')
 
+var path = require('path')
+
 var util = require('./_util')
 var multer = require('../')
 var temp = require('fs-temp')
@@ -129,8 +131,8 @@ describe('Functionality', function () {
     util.submitForm(parser, form, function (err, req) {
       assert.ifError(err)
       assert.strictEqual(req.files.length, 2)
-      assert.ok(req.files[0].path.indexOf('/testforme-') >= 0)
-      assert.ok(req.files[1].path.indexOf('/testforme-') >= 0)
+      assert.ok(req.files[0].path.indexOf(path.sep + 'testforme-') >= 0)
+      assert.ok(req.files[1].path.indexOf(path.sep + 'testforme-') >= 0)
       done()
     })
   })


### PR DESCRIPTION
## Summary

Fixes #1451.

The `should rename the destination directory to a different directory` test in `test/functionality.js` hardcodes `/` as the path separator in its assertions:

```js
assert.ok(req.files[0].path.indexOf('/testforme-') >= 0)
assert.ok(req.files[1].path.indexOf('/testforme-') >= 0)
```

On Windows, `path` uses `\` as the separator, so `indexOf('/testforme-')` returns `-1` and the test fails even though the upload directory was correctly created by `fs-temp`.

## Fix

Replace the hardcoded `'/'` with `path.sep` so the assertion holds on both POSIX and Windows:

```js
assert.ok(req.files[0].path.indexOf(path.sep + 'testforme-') >= 0)
assert.ok(req.files[1].path.indexOf(path.sep + 'testforme-') >= 0)
```

A `require('path')` is added at the top of the file. No production code is changed — only the test assertion.

## Test plan

- [x] Ran `npx mocha --exit --timeout 30000 test/functionality.js` on Windows:
  - `should rename the destination directory to a different directory` ✔ passes (was failing before on Windows)
  - `should rename the uploaded file` ✔
  - `should ensure all req.files values (single-file per field) point to an array` ✔
  - `should ensure all req.files values (multi-files per field) point to an array` ✔
- [x] Diff is minimal: 1 file changed, 4 insertions(+), 2 deletions(-)
- [x] No production code (`lib/`, `storage/`, `index.js`) touched

## Notes

- A separate, pre-existing Windows environment issue exists in this repo: `test/files/small0.dat` is a text fixture with LF line endings, but the repo has no `.gitattributes` pinning it to binary/LF. Git's autocrlf on Windows converts LF to CRLF, inflating the file from 1778 to 1803 bytes, which causes the unrelated `should upload the file to the dest dir` test to fail on `assert.strictEqual(util.fileSize(req.file.path), 1778)`. That is **out of scope** for #1451 (which is specifically about the path separator) and is not addressed by this PR to keep the diff focused.
