### PR TITLE
test: add coverage for preservePath

### DIFF
--- a/test/preserve-path.js
+++ b/test/preserve-path.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var util = require('./_util')
+var multer = require('../')
+var FormData = require('form-data')
+
+function submitFile (parser, filepath, cb) {
+  var form = new FormData()
+
+  form.append('file', util.file('tiny0.dat'), { filepath: filepath })
+
+  util.submitForm(parser, form, cb)
+}
+
+describe('Preserve Path', function () {
+  it('should strip the path by default', function (done) {
+    submitFile(multer().single('file'), 'a/b/c.txt', function (err, req) {
+      assert.ifError(err)
+
+      assert.strictEqual(req.file.fieldname, 'file')
+      assert.strictEqual(req.file.originalname, 'c.txt')
+
+      done()
+    })
+  })
+
+  it('should keep the full path when enabled', function (done) {
+    var parser = multer({ preservePath: true }).single('file')
+
+    submitFile(parser, 'a/b/c.txt', function (err, req) {
+      assert.ifError(err)
+
+      assert.strictEqual(req.file.fieldname, 'file')
+      assert.strictEqual(req.file.originalname, 'a/b/c.txt')
+
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Closes #1453.

`preservePath` had no test coverage — `grep -r preservePath test/` returned nothing — even though it changes what consumers see in `file.originalname`. This adds the two cases described in the issue:

- **default (`preservePath` unset):** a file sent as `filename="a/b/c.txt"` arrives with `originalname === 'c.txt'`
- **`preservePath: true`:** the same upload keeps `originalname === 'a/b/c.txt'`

Both go through `util.submitForm` like the existing tests. The full client path is set with `form-data`'s `filepath` option, since `filename` is passed through `path.basename` internally and so can't express the path segments this option exists to preserve.

Verified the assertions actually exercise the option: forcing `preservePath: false` in `lib/make-middleware.js` fails the second case with `-c.txt` / `+a/b/c.txt`, and it passes again once reverted.

`npm test` goes from 84 to 86 passing, and `npm run lint` is clean. No source or existing test files are touched.
