### PR TITLE
2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.0
+
+- Fix [CVE-2026-77078](https://www.cve.org/CVERecord?id=CVE-2026-77078) ([GHSA-wc9g-mqfw-jrwm](https://github.com/expressjs/multer/security/advisories/GHSA-wc9g-mqfw-jrwm))
+- Fix [CVE-2026-77037](https://www.cve.org/CVERecord?id=CVE-2026-77037) ([GHSA-qfvm-cv95-jqjf](https://github.com/expressjs/multer/security/advisories/GHSA-qfvm-cv95-jqjf))
+- Fix [CVE-2026-77063](https://www.cve.org/CVERecord?id=CVE-2026-77063) ([GHSA-qvfw-j98x-7q72](https://github.com/expressjs/multer/security/advisories/GHSA-qvfw-j98x-7q72))
+- Fix [CVE-2026-82333](https://www.cve.org/CVERecord?id=CVE-2026-82333) ([GHSA-535w-7cp7-47q4](https://github.com/expressjs/multer/security/advisories/GHSA-535w-7cp7-47q4))
+- Add `MulterError` codes `INVALID_FIELD_NAME` and `STREAM_DESTROYED`
+- Add opt-in `limits.fieldArrayIndexLimit` to bound numeric array indexes in field names ([#1438](https://github.com/expressjs/multer/pull/1438))
+- Accept files whose size is exactly `limits.fileSize` ([#1407](https://github.com/expressjs/multer/pull/1407))
+- Preserve the caller's async context (`AsyncLocalStorage`) when calling `next()` ([#1124](https://github.com/expressjs/multer/pull/1124))
+- Decode WHATWG-escaped characters (`%0A`, `%0D`, `%22`) in `file.originalname` ([#1421](https://github.com/expressjs/multer/pull/1421))
+- Do not crash when `fileFilter` invokes its callback more than once ([#1427](https://github.com/expressjs/multer/pull/1427))
+- Use a fallback message for `MulterError` codes without a mapping ([#1448](https://github.com/expressjs/multer/pull/1448))
+- Docs: clarify `preservePath` and `parts`, use `crypto.randomBytes` in the `DiskStorage` example ([#1414](https://github.com/expressjs/multer/pull/1414), [#1430](https://github.com/expressjs/multer/pull/1430), [#1436](https://github.com/expressjs/multer/pull/1436))
+- Docs: add Indonesian, Japanese and Tamil translations and refresh all translations from the current README ([#1431](https://github.com/expressjs/multer/pull/1431), [#1354](https://github.com/expressjs/multer/pull/1354), [#1462](https://github.com/expressjs/multer/pull/1462))
+- Internal: run the test suite on Windows ([#1334](https://github.com/expressjs/multer/pull/1334))
+
 ## 2.2.0
 
 - Fix [CVE-2026-5038](https://www.cve.org/CVERecord?id=CVE-2026-5038) ([GHSA-3p4h-7m6x-2hcm](https://github.com/expressjs/multer/security/advisories/GHSA-3p4h-7m6x-2hcm))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multer",
   "description": "Middleware for handling `multipart/form-data`.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "contributors": [
     "Hage Yaapa <captain@hacksparrow.com> (http://www.hacksparrow.com)",
     "Jaret Pfluger <https://github.com/jpfluger>",


### PR DESCRIPTION
### What's included in the `CHANGELOG.md`

```
## 2.3.0

- Fix [CVE-2026-77078](https://www.cve.org/CVERecord?id=CVE-2026-77078) ([GHSA-wc9g-mqfw-jrwm](https://github.com/expressjs/multer/security/advisories/GHSA-wc9g-mqfw-jrwm))
- Fix [CVE-2026-77037](https://www.cve.org/CVERecord?id=CVE-2026-77037) ([GHSA-qfvm-cv95-jqjf](https://github.com/expressjs/multer/security/advisories/GHSA-qfvm-cv95-jqjf))
- Fix [CVE-2026-77063](https://www.cve.org/CVERecord?id=CVE-2026-77063) ([GHSA-qvfw-j98x-7q72](https://github.com/expressjs/multer/security/advisories/GHSA-qvfw-j98x-7q72))
- Fix [CVE-2026-82333](https://www.cve.org/CVERecord?id=CVE-2026-82333) ([GHSA-535w-7cp7-47q4](https://github.com/expressjs/multer/security/advisories/GHSA-535w-7cp7-47q4))
- Add `MulterError` codes `INVALID_FIELD_NAME` and `STREAM_DESTROYED`
- Add opt-in `limits.fieldArrayIndexLimit` to bound numeric array indexes in field names ([#1438](https://github.com/expressjs/multer/pull/1438))
- Accept files whose size is exactly `limits.fileSize` ([#1407](https://github.com/expressjs/multer/pull/1407))
- Preserve the caller's async context (`AsyncLocalStorage`) when calling `next()` ([#1124](https://github.com/expressjs/multer/pull/1124))
- Decode WHATWG-escaped characters (`%0A`, `%0D`, `%22`) in `file.originalname` ([#1421](https://github.com/expressjs/multer/pull/1421))
- Do not crash when `fileFilter` invokes its callback more than once ([#1427](https://github.com/expressjs/multer/pull/1427))
- Use a fallback message for `MulterError` codes without a mapping ([#1448](https://github.com/expressjs/multer/pull/1448))
- Docs: clarify `preservePath` and `parts`, use `crypto.randomBytes` in the `DiskStorage` example ([#1414](https://github.com/expressjs/multer/pull/1414), [#1430](https://github.com/expressjs/multer/pull/1430), [#1436](https://github.com/expressjs/multer/pull/1436))
- Docs: add Indonesian, Japanese and Tamil translations and refresh all translations from the current README ([#1431](https://github.com/expressjs/multer/pull/1431), [#1354](https://github.com/expressjs/multer/pull/1354), [#1462](https://github.com/expressjs/multer/pull/1462))
- Internal: run the test suite on Windows ([#1334](https://github.com/expressjs/multer/pull/1334))
```

## What's Changed
* Update busboy link pointing to nonexistent section by @krzysdz in https://github.com/expressjs/multer/pull/1447
* Update outdated links to Express error handling guide by @krzysdz in https://github.com/expressjs/multer/pull/1405
* chore(deps): bump GitHub Actions and dev dependencies by @sheplu in https://github.com/expressjs/multer/pull/1445
* chore(ci): npm-publish via reusable workflows by @sheplu in https://github.com/expressjs/multer/pull/1364
* fix(tests): keep Git from rewriting fixture line endings on Windows by @MohammedAlkindi in https://github.com/expressjs/multer/pull/1450
* docs: correct fieldNameSize default in limits table by @UlisesGascon in https://github.com/expressjs/multer/pull/1432
* feat: normalize package.json by @UlisesGascon in https://github.com/expressjs/multer/pull/1322
* fix(test): use path.sep for cross-platform path assertions by @kilisamemarisaaa in https://github.com/expressjs/multer/pull/1452
* docs(changelog): fix typo 'comaptible' to 'compatible' by @ayushshukla1807 in https://github.com/expressjs/multer/pull/1383
* doc: adds context for link to Chinese README by @sunsheeppoplar in https://github.com/expressjs/multer/pull/1369
* docs: use crypto.randomBytes in diskStorage README example by @Hashim1999164 in https://github.com/expressjs/multer/pull/1436
* docs: clarify preservePath behavior by @vibhor-aggr in https://github.com/expressjs/multer/pull/1414
* docs: clarify parts limit behavior by @vibhor-aggr in https://github.com/expressjs/multer/pull/1430
* chore: increase test coverage by @wojtekmaj in https://github.com/expressjs/multer/pull/1355
* chore: drop deep-equal devDependency by @wojtekmaj in https://github.com/expressjs/multer/pull/1353
* docs: fix Chinese README translation by @vibhor-aggr in https://github.com/expressjs/multer/pull/1429
* Test: Enhance cross-platform test reliability and update CI workflow by @ShubhamOulkar in https://github.com/expressjs/multer/pull/1334
* fix: fallback to error code when no message mapping exists by @sahilraut191685 in https://github.com/expressjs/multer/pull/1448
* test: add coverage for preservePath by @kory-kaai in https://github.com/expressjs/multer/pull/1454
* fix: prevent process crash when fileFilter calls its callback more than once by @spokodev in https://github.com/expressjs/multer/pull/1427
* fix: preserve async hooks context in supported environments by @ajhyndman in https://github.com/expressjs/multer/pull/1124
* fix: allow files at exact fileSize limit by @raashish1601 in https://github.com/expressjs/multer/pull/1407
* fix: decode WHATWG-escaped characters in file originalname by @webdevelopersrinu in https://github.com/expressjs/multer/pull/1421
* docs: add Indonesian translation for README by @Derylfabiensyah in https://github.com/expressjs/multer/pull/1431
* test: accept files exactly at fileSize limit by @abhu85 in https://github.com/expressjs/multer/pull/1382
* docs: add Japanese translation to README by @noritaka1166 in https://github.com/expressjs/multer/pull/1354
* Update 'README-zh-cn.md' up to now by @pbstar in https://github.com/expressjs/multer/pull/1264
* feat: add an opt-in fieldArrayIndexLimit by @arpitjain099 in https://github.com/expressjs/multer/pull/1438
* docs: refresh all README translations by @UlisesGascon in https://github.com/expressjs/multer/pull/1462

## New Contributors
* @krzysdz made their first contribution in https://github.com/expressjs/multer/pull/1447
* @sheplu made their first contribution in https://github.com/expressjs/multer/pull/1445
* @MohammedAlkindi made their first contribution in https://github.com/expressjs/multer/pull/1450
* @kilisamemarisaaa made their first contribution in https://github.com/expressjs/multer/pull/1452
* @ayushshukla1807 made their first contribution in https://github.com/expressjs/multer/pull/1383
* @sunsheeppoplar made their first contribution in https://github.com/expressjs/multer/pull/1369
* @Hashim1999164 made their first contribution in https://github.com/expressjs/multer/pull/1436
* @vibhor-aggr made their first contribution in https://github.com/expressjs/multer/pull/1414
* @sahilraut191685 made their first contribution in https://github.com/expressjs/multer/pull/1448
* @kory-kaai made their first contribution in https://github.com/expressjs/multer/pull/1454
* @spokodev made their first contribution in https://github.com/expressjs/multer/pull/1427
* @ajhyndman made their first contribution in https://github.com/expressjs/multer/pull/1124
* @raashish1601 made their first contribution in https://github.com/expressjs/multer/pull/1407
* @webdevelopersrinu made their first contribution in https://github.com/expressjs/multer/pull/1421
* @Derylfabiensyah made their first contribution in https://github.com/expressjs/multer/pull/1431
* @abhu85 made their first contribution in https://github.com/expressjs/multer/pull/1382
* @noritaka1166 made their first contribution in https://github.com/expressjs/multer/pull/1354
* @pbstar made their first contribution in https://github.com/expressjs/multer/pull/1264
* @arpitjain099 made their first contribution in https://github.com/expressjs/multer/pull/1438

**Full Changelog**: https://github.com/expressjs/multer/compare/v2.2.0...main
