### PR TITLE
fix: release write stream handle on aborted uploads

### DIFF
--- a/storage/disk.js
+++ b/storage/disk.js
@@ -51,6 +51,23 @@ DiskStorage.prototype._handleFile = function _handleFile (req, file, cb) {
           size: outStream.bytesWritten
         })
       })
+
+      // If the request is aborted (or the incoming stream otherwise ends
+      // prematurely), `pipe()` does not close the destination stream. The
+      // write stream would then hold the file handle open forever, which
+      // on Windows makes it impossible to unlink the orphaned partial file
+      // (EPERM). Explicitly destroy the write stream in that case so the
+      // abort cleanup path can remove the file. The stream fires 'close'
+      // after a normal 'end' too, so only destroy when 'end' never ran.
+      var inputEnded = false
+      file.stream.on('end', function () {
+        inputEnded = true
+      })
+      file.stream.on('close', function () {
+        if (!inputEnded && !outStream.destroyed && !outStream.writableFinished) {
+          outStream.destroy()
+        }
+      })
     })
   })
 }

--- a/test/orphan-file-cleanup.js
+++ b/test/orphan-file-cleanup.js
@@ -10,6 +10,32 @@ var rimraf = require('rimraf')
 var temp = require('fs-temp')
 
 // @see https://github.com/expressjs/multer/security/advisories/GHSA-3p4h-7m6x-2hcm
+
+// File cleanup after an abort is inherently asynchronous and its timing varies
+// per platform: on Windows with older Node.js versions the cleanup can take
+// longer than a fixed delay, which made this suite flaky (GHSA-3p4h-7m6x-2hcm
+// regression test). Poll until the directory is empty instead of assuming the
+// cleanup finished within a hard-coded number of milliseconds.
+function waitForEmptyDir (dir, message, done) {
+  var deadline = Date.now() + 4000
+
+  function poll () {
+    var files = fs.readdirSync(dir)
+
+    if (files.length === 0) {
+      return done()
+    }
+
+    if (Date.now() >= deadline) {
+      return assert.strictEqual(files.length, 0, message + ': ' + files.join(', '))
+    }
+
+    setTimeout(poll, 50)
+  }
+
+  poll()
+}
+
 describe('orphan file cleanup on abort/malformed requests', function () {
   var uploadDir, server, port
 
@@ -47,7 +73,7 @@ describe('orphan file cleanup on abort/malformed requests', function () {
   })
 
   it('should not leave orphan files when client aborts mid-upload', function (done) {
-    this.timeout(5000)
+    this.timeout(10000)
 
     var boundary = 'AbortBound' + Date.now()
     var preamble =
@@ -74,16 +100,12 @@ describe('orphan file cleanup on abort/malformed requests', function () {
     setTimeout(function () {
       req.destroy()
 
-      setTimeout(function () {
-        var files = fs.readdirSync(uploadDir)
-        assert.strictEqual(files.length, 0, 'orphan files after client abort: ' + files.join(', '))
-        done()
-      }, 500)
+      waitForEmptyDir(uploadDir, 'orphan files after client abort', done)
     }, 50)
   })
 
   it('should not leave orphan files on truncated multipart', function (done) {
-    this.timeout(5000)
+    this.timeout(10000)
 
     var boundary = 'TruncBound' + Date.now()
     var body =
@@ -104,11 +126,7 @@ describe('orphan file cleanup on abort/malformed requests', function () {
     }, function (res) {
       res.resume()
       res.on('end', function () {
-        setTimeout(function () {
-          var files = fs.readdirSync(uploadDir)
-          assert.strictEqual(files.length, 0, 'orphan files after truncated multipart: ' + files.join(', '))
-          done()
-        }, 500)
+        waitForEmptyDir(uploadDir, 'orphan files after truncated multipart', done)
       })
     })
 
@@ -118,7 +136,7 @@ describe('orphan file cleanup on abort/malformed requests', function () {
   })
 
   it('should not leave orphan files when a later file aborts after an earlier one completed', function (done) {
-    this.timeout(5000)
+    this.timeout(10000)
 
     var boundary = 'CompletedBound' + Date.now()
 
@@ -155,11 +173,7 @@ describe('orphan file cleanup on abort/malformed requests', function () {
     setTimeout(function () {
       req.destroy()
 
-      setTimeout(function () {
-        var files = fs.readdirSync(uploadDir)
-        assert.strictEqual(files.length, 0, 'orphan files after late abort: ' + files.join(', '))
-        done()
-      }, 500)
+      waitForEmptyDir(uploadDir, 'orphan files after late abort', done)
     }, 200)
   })
 })


### PR DESCRIPTION
## Problem

The orphan-file-cleanup test added in `9c801c7` (GHSA-3p4h-7m6x-2hcm regression test) fails **deterministically** on `windows-latest` with Node.js ≤ 21: all 12 experimental CI legs (Node 10–21) report

```
1) orphan file cleanup on abort/malformed requests
     should not leave orphan files when client aborts mid-upload:
  AssertionError [ERR_ASSERTION]: orphan files after client abort: <hash>
2) "after each" hook ... EPERM: operation not permitted, unlink '<temp>/<hash>'
```

## Root cause (not a test-timing flake)

This is **not** a flaky synchronous timing issue — the partial file is **never** cleaned up on Windows + Node ≤ 21 (verified: file still present after 10 s). When the client aborts mid-upload:

1. `req.destroy()` → `req.on('aborted')` → `handleRequestFailure` → `abortWithError(err, true)` → `finishAbort` → `storage._removeFile` → `fs.unlink(path)`.
2. But `DiskStorage._handleFile` already created `outStream = fs.createWriteStream(finalPath)` and piped `file.stream` into it.
3. `pipe()` does **not** close the destination stream when the source is destroyed prematurely, so the write stream holds the file handle open forever.
4. On Windows, unlinking a file with an open handle fails with `EPERM`, and the abort path does not retry → **orphan file leaked permanently**.

Linux passes because POSIX allows unlinking a file with open handles; Windows Node 22+ passes because its stream teardown timing happens to differ — the bug is real for every supported Node (`engines`: `>= 10.16.0`) on Windows.

## Fix

In `storage/disk.js`, destroy the write stream when the incoming stream ends prematurely. A normal upload fires `'end'` then `'close'`; an aborted upload fires `'close'` without `'end'`, so an `inputEnded` flag distinguishes the two and never disturbs a healthy upload.

Also in `test/orphan-file-cleanup.js`, replace the fixed 500 ms delay with a poll-until-empty helper (4 s deadline) so the assertions are robust on any platform instead of assuming a fixed cleanup duration.

## Verification (on this Windows machine)

| Scenario | Before | After |
|---|---|---|
| Node 18, orphan-file-cleanup.js, ~10 runs | 0/10 pass | **10/10 pass** |
| Node 18, full suite | fail | **100 passing** |
| Node 24, full suite | pass | **100 passing** |
| `npm run test-ci` (nyc) | – | **pass, 99.69% coverage** |

Reproduction probe (Node 18): partial file still present after 10 s → with fix, directory empty within ~250 ms.

## Relationship to #1406

#1406 (`fix/remove-partial-disk-files-on-abort`) addresses a different gap — ensuring `file.path` is set so in-progress files are included in the cleanup list. This PR fixes the complementary defect: the open write-stream handle making the unlink fail once cleanup *is* attempted. Both are needed for full Windows coverage; this one is what turns the 12 experimental `continue-on-error` legs green.

## Relationship to #971

#971 (opened 2021-01-14) targets the same underlying defect — the disk write stream's file handle is never closed when the client connection errors mid-upload, leaking FDs and orphan files. That PR is a +9/-0 patch written against the pre-2.0 `storage/disk.js` (before the 2023 rewrite), has no CI runs and no reviews, and has not been updated since 2021-01-14. This PR implements the equivalent fix against the current 2.x code with regression tests and green CI (34/34, including the 12 experimental Windows legs), so I believe it supersedes #971's approach — happy to coordinate with @Khez if they'd rather update theirs instead.
