### PR TITLE
feat: add streamHandler option to feed busboy from pre-consumed bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Key | Description
 `limits` | Limits of the uploaded data
 `preservePath` | Keep the full client-supplied path in `file.originalname` instead of just the base name
 `defParamCharset` | Default character set to use for values of part header parameters (e.g. filename) that are not extended parameters (that contain an explicit charset). Default: `'latin1'`
+`streamHandler` | Function that feeds the request body to busboy; defaults to `req.pipe(busboy)`
 
 In an average web app, only `dest` might be required, and configured as shown in
 the following example.
@@ -306,6 +307,30 @@ function fileFilter (req, file, cb) {
 
 }
 ```
+
+### `streamHandler`
+
+By default Multer reads the request with `req.pipe(busboy)`. Some platforms
+consume the request body before your handlers run, so there is nothing left to
+pipe. Google Cloud Functions and Firebase Functions, for example, expose the
+already-read body as `req.rawBody`. Provide a `streamHandler` to feed busboy
+yourself in that case:
+
+```javascript
+const upload = multer({
+  storage: multer.memoryStorage(),
+  streamHandler: function (req, busboy) {
+    if (req.rawBody) {
+      busboy.end(req.rawBody)
+    } else {
+      req.pipe(busboy)
+    }
+  }
+})
+```
+
+The function receives the request and the busboy instance and must write the
+whole multipart body to busboy and end it.
 
 ## Security
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ function Multer (options) {
   this.preservePath = options.preservePath
   this.defParamCharset = options.defParamCharset || 'latin1'
   this.fileFilter = options.fileFilter || allowAll
+
+  if (options.streamHandler !== undefined && typeof options.streamHandler !== 'function') {
+    throw new TypeError('Expected streamHandler to be a function')
+  }
+
+  this.streamHandler = options.streamHandler
 }
 
 Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
@@ -49,6 +55,7 @@ Multer.prototype._makeMiddleware = function (fields, fileStrategy) {
       limits: this.limits,
       preservePath: this.preservePath,
       defParamCharset: this.defParamCharset,
+      streamHandler: this.streamHandler,
       storage: this.storage,
       fileFilter: wrappedFileFilter,
       fileStrategy: fileStrategy
@@ -80,6 +87,7 @@ Multer.prototype.any = function () {
       limits: this.limits,
       preservePath: this.preservePath,
       defParamCharset: this.defParamCharset,
+      streamHandler: this.streamHandler,
       storage: this.storage,
       fileFilter: this.fileFilter,
       fileStrategy: 'ARRAY'

--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -53,6 +53,13 @@ function decodeFormDataName (str) {
   })
 }
 
+// By default the request is piped into busboy. Environments that have already
+// consumed the request body (e.g. Google Cloud Functions, which exposes it as
+// `req.rawBody`) can provide a `streamHandler` that feeds busboy instead.
+function defaultStreamHandler (req, busboy) {
+  req.pipe(busboy)
+}
+
 function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
     // Preserve the caller's async context (AsyncLocalStorage, CLS) across the
@@ -89,6 +96,7 @@ function makeMiddleware (setup) {
     var fileStrategy = options.fileStrategy
     var preservePath = options.preservePath
     var defParamCharset = options.defParamCharset
+    var streamHandler = options.streamHandler || defaultStreamHandler
 
     req.body = Object.create(null)
 
@@ -350,7 +358,7 @@ function makeMiddleware (setup) {
       indicateDone()
     })
 
-    req.pipe(busboy)
+    streamHandler(req, busboy)
   }
 }
 

--- a/test/stream-handler.js
+++ b/test/stream-handler.js
@@ -1,0 +1,132 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+var stream = require('stream')
+var FormData = require('form-data')
+
+var multer = require('../')
+var util = require('./_util')
+
+// Builds a request whose body has already been consumed by the platform and
+// is only available as `req.rawBody`, like Google Cloud Functions does.
+function preConsumedRequest (form, cb) {
+  var chunks = []
+
+  form.on('data', function (chunk) { chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)) })
+  form.on('end', function () {
+    var body = Buffer.concat(chunks)
+    var req = new stream.PassThrough()
+
+    req.headers = {
+      'content-type': 'multipart/form-data; boundary=' + form.getBoundary(),
+      'content-length': body.length
+    }
+    req.rawBody = body
+    req.resume()
+    req.end()
+    req.on('end', function () { cb(req) })
+  })
+  form.resume()
+}
+
+function rawBodyHandler (req, busboy) {
+  if (req.rawBody) {
+    busboy.end(req.rawBody)
+  } else {
+    req.pipe(busboy)
+  }
+}
+
+describe('Stream handler', function () {
+  it('should pipe the request by default', function (done) {
+    var form = new FormData()
+    var parser = multer().single('file')
+
+    form.append('name', 'Multer')
+    form.append('file', util.file('small0.dat'))
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.body.name, 'Multer')
+      assert.strictEqual(req.file.originalname, 'small0.dat')
+      done()
+    })
+  })
+
+  it('should read a pre-consumed body through the stream handler', function (done) {
+    var form = new FormData()
+    var parser = multer({ streamHandler: rawBodyHandler }).single('file')
+
+    form.append('name', 'Multer')
+    form.append('file', util.file('small0.dat'))
+
+    preConsumedRequest(form, function (req) {
+      assert.strictEqual(req.readable, false)
+
+      parser(req, null, function (err) {
+        assert.ifError(err)
+        assert.strictEqual(req.body.name, 'Multer')
+        assert.strictEqual(req.file.originalname, 'small0.dat')
+        assert.strictEqual(req.file.size, 1778)
+        done()
+      })
+    })
+  })
+
+  it('should apply the stream handler to .any() as well', function (done) {
+    var form = new FormData()
+    var parser = multer({ streamHandler: rawBodyHandler }).any()
+
+    form.append('file', util.file('small0.dat'))
+
+    preConsumedRequest(form, function (req) {
+      parser(req, null, function (err) {
+        assert.ifError(err)
+        assert.strictEqual(req.files.length, 1)
+        done()
+      })
+    })
+  })
+
+  it('should call the stream handler once with the request and busboy', function (done) {
+    var calls = []
+    var form = new FormData()
+    var parser = multer({
+      streamHandler: function (req, busboy) {
+        calls.push([req, busboy])
+        req.pipe(busboy)
+      }
+    }).none()
+
+    form.append('name', 'Multer')
+
+    util.submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(calls.length, 1)
+      assert.strictEqual(calls[0][0], req)
+      assert.strictEqual(typeof calls[0][1].end, 'function')
+      done()
+    })
+  })
+
+  it('should report errors through next() with a pre-consumed body', function (done) {
+    var form = new FormData()
+    var parser = multer({ streamHandler: rawBodyHandler, limits: { fileSize: 100 } }).single('file')
+
+    form.append('file', util.file('small0.dat'))
+
+    preConsumedRequest(form, function (req) {
+      parser(req, null, function (err) {
+        assert.ok(err)
+        assert.strictEqual(err.code, 'LIMIT_FILE_SIZE')
+        done()
+      })
+    })
+  })
+
+  it('should reject a stream handler that is not a function', function () {
+    assert.throws(function () {
+      multer({ streamHandler: 'nope' })
+    }, /Expected streamHandler to be a function/)
+  })
+})


### PR DESCRIPTION
Adds an optional `streamHandler(req, busboy)` to `multer(opts)`. By default multer keeps doing `req.pipe(busboy)`; platforms that consume the request body before Express runs (Google Cloud Functions / Firebase Functions expose it as `req.rawBody`) can feed busboy themselves — the README shows the `rawBody` snippet. Nothing changes when the option is not set. Tests cover a request whose body is only available in `req.rawBody`, including the error path, and `.any()`.

Based on #1307, with the `rawBody` case actually tested, a `TypeError` for a non-function value, and no special-casing of `unpipe`. Credits the authors of #1307, #789, #796 and #1211 as co-authors.

Closes #1307
Closes #789
Closes #796
Closes #1211
Closes #1189
Closes #572
