### PR TITLE
docs: describe the file stream contract for storage engines

### DIFF
--- a/StorageEngine.md
+++ b/StorageEngine.md
@@ -26,6 +26,19 @@ The file data will be given to you as a stream (`file.stream`). You should pipe
 this data somewhere, and when you are done, call `cb` with some information on the
 file.
 
+A few rules about `file.stream`:
+
+- Always consume it. If you decide not to store the rest of a file, call
+  `file.stream.resume()` to discard it and then call `cb`; parsing continues
+  with the next part. Do not call `file.stream.destroy()`: busboy cannot
+  continue after a destroyed part stream and the request would hang.
+- When the request is aborted or fails, `file.stream` emits `error` and `close`.
+  Use `stream.pipeline(file.stream, yourStream, cb)` rather than `pipe()`, so
+  your output stream is destroyed and `cb` is called with the error in that
+  case. Multer then calls `_removeFile` for the files that were already stored,
+  and for files still being written if `file.path` (or whatever `_removeFile`
+  needs) has been set on the file object, so set it before you start writing.
+
 The information you provide in the callback will be merged with multer's file object,
 and then presented to the user via `req.files`.
 
@@ -38,6 +51,7 @@ implement the `_removeFile` function. It will receive the same arguments as
 
 ```javascript
 var fs = require('fs')
+var pipeline = require('stream').pipeline
 
 function getDestination (req, file, cb) {
   cb(null, '/dev/null')
@@ -53,9 +67,12 @@ MyCustomStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
     var outStream = fs.createWriteStream(path)
 
-    file.stream.pipe(outStream)
-    outStream.on('error', cb)
-    outStream.on('finish', function () {
+    // Lets multer remove a partially written file if the request fails
+    file.path = path
+
+    pipeline(file.stream, outStream, function (err) {
+      if (err) return cb(err)
+
       cb(null, {
         path: path,
         size: outStream.bytesWritten


### PR DESCRIPTION
Documents in StorageEngine.md what a custom engine must do with `file.stream`:

- always consume it; call `file.stream.resume()` to discard the rest of a file, never `destroy()` (busboy cannot continue after a destroyed part stream and the request hangs; see #1277)
- on an aborted request `file.stream` emits `error` and `close`; use `stream.pipeline(file.stream, out, cb)` so the output stream is destroyed and `cb` gets the error (see #1459, #1300)
- set `file.path` before writing so multer can call `_removeFile` for a partially written file

The template is updated accordingly (it used bare `pipe()` + `finish`) and was run through a normal and an aborted upload: no leftover file after abort.