### PR TITLE
ci: close stale issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Close stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  # Needed to label and comment on stale issues
+  issues: write
+  # Needed to label and comment on stale pull requests
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: 'This issue has been inactive for 30 days. It will be closed in 30 days unless there is further activity or the stale label is removed.'
+          stale-pr-message: 'This pull request has been inactive for 30 days. It will be closed in 30 days unless there is further activity or the stale label is removed.'
+          exempt-issue-labels: 'security-release,help wanted,good first issue,release'
+          exempt-pr-labels: 'security-release,release'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,5 +23,5 @@ jobs:
           stale-pr-label: stale
           stale-issue-message: 'This issue has been inactive for 30 days. It will be closed in 30 days unless there is further activity or the stale label is removed.'
           stale-pr-message: 'This pull request has been inactive for 30 days. It will be closed in 30 days unless there is further activity or the stale label is removed.'
-          exempt-issue-labels: 'security-release,help wanted,good first issue,release'
-          exempt-pr-labels: 'security-release,release'
+          exempt-issue-labels: 'never-stale,security-release,help wanted,good first issue,release'
+          exempt-pr-labels: 'never-stale,security-release,release'


### PR DESCRIPTION
Adds a daily `actions/stale` workflow (pinned to v11.0.0), modelled on the one in nodejs/security-wg: issues and pull requests with no activity for 30 days get the `stale` label and a comment, and are closed after another 30 days unless there is activity or the label is removed.

Exempt labels: `security-release`, `release` (issues and PRs), plus `help wanted` and `good first issue` (issues), so tracked work is never auto-closed.