### PR TITLE
docs: make StorageEngine template handle string destination

### DIFF
--- a/StorageEngine.md
+++ b/StorageEngine.md
@@ -34,6 +34,10 @@ later on. Multer will decide which files to delete and when. Your storage class 
 implement the `_removeFile` function. It will receive the same arguments as
 `_handleFile`. Invoke the callback once the file has been removed.
 
+The `destination` option may be given either as a string directory path or as a
+`function (req, file, cb)`, mirroring the option accepted by
+`multer.diskStorage()`. The template below accepts both forms.
+
 ## Template
 
 ```javascript
@@ -44,7 +48,16 @@ function getDestination (req, file, cb) {
 }
 
 function MyCustomStorage (opts) {
-  this.getDestination = (opts.destination || getDestination)
+  var destination = (opts.destination || getDestination)
+
+  // Accept a string directory path as well as a function,
+  // the same way multer's own DiskStorage does.
+  if (typeof destination === 'string') {
+    var dir = destination
+    destination = function (req, file, cb) { cb(null, dir) }
+  }
+
+  this.getDestination = destination
 }
 
 MyCustomStorage.prototype._handleFile = function _handleFile (req, file, cb) {


### PR DESCRIPTION
Fixes #1278

## Problem

The custom storage engine template in `StorageEngine.md` assigns
`opts.destination || getDestination` directly to `this.getDestination`, then calls
`this.getDestination(req, file, cb)`. `destination` documented and supported by
`multer.diskStorage()` includes the **string directory path** form — with that form
the template throws `TypeError: this.getDestination is not a function`, because a
string is not callable.

## Fix

- Normalize the option in the constructor exactly the way `storage/disk.js` does:
  when `destination` is a string, wrap it into a `(req, file, cb)` function before
  assigning to `this.getDestination`.
- Add one prose sentence stating that `destination` may be a string path or a
  function, mirroring `multer.diskStorage()`.

Docs-only change; no runtime code touched. The template's behavior now matches
the built-in DiskStorage for both option forms.

## Verification

- Template snippet copy-pasted into a scratch engine and exercised with both
  `destination: '/tmp/uploads'` and `destination: fn` — both resolve a path and
  write the file; the string form no longer throws.
- Docs-only diff (`git diff --stat`: 1 file changed, StorageEngine.md only).
