### PR TITLE
fix: decode escaped field names, not just filenames

### DIFF
--- a/lib/make-middleware.js
+++ b/lib/make-middleware.js
@@ -230,12 +230,18 @@ function makeMiddleware (setup) {
     // handle text field data
     busboy.on('field', function (fieldname, value, { nameTruncated, valueTruncated }) {
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
+
+      // fieldNameSize limits the name as it arrived, so keep the raw form for
+      // that check before the escapes are reversed.
+      var rawFieldname = fieldname
+      fieldname = decodeFormDataName(fieldname)
+
       if (nameTruncated) return abortWithCode('LIMIT_FIELD_KEY')
       if (valueTruncated) return abortWithCode('LIMIT_FIELD_VALUE', fieldname)
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
-        if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
+        if (rawFieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNestingDepth')) {
@@ -285,12 +291,17 @@ function makeMiddleware (setup) {
 
       if (fieldname == null) return abortWithCode('MISSING_FIELD_NAME')
 
+      // fieldNameSize limits the name as it arrived, so keep the raw form for
+      // that check before the escapes are reversed.
+      var rawFieldname = fieldname
+      fieldname = decodeFormDataName(fieldname)
+
       // don't attach to the files object, if there is no file
       if (!filename) return fileStream.resume()
 
       // Work around bug in Busboy (https://github.com/mscdex/busboy/issues/6)
       if (limits && Object.prototype.hasOwnProperty.call(limits, 'fieldNameSize')) {
-        if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
+        if (rawFieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 
       var file = {

--- a/test/fieldname-decoding.js
+++ b/test/fieldname-decoding.js
@@ -1,0 +1,92 @@
+/* eslint-env mocha */
+
+var assert = require('assert')
+
+var multer = require('../')
+var stream = require('stream')
+
+function submit (middleware, part, cb) {
+  var req = new stream.PassThrough()
+  var boundary = 'AaB03x'
+  var body = [
+    '--' + boundary,
+    part,
+    'Content-Type: text/plain',
+    '',
+    'test content',
+    '--' + boundary + '--'
+  ].join('\r\n')
+
+  req.headers = {
+    'content-type': 'multipart/form-data; boundary=' + boundary,
+    'content-length': body.length
+  }
+
+  req.end(body)
+
+  middleware(req, null, function (err) {
+    if (err) return cb(err)
+    cb(null, req)
+  })
+}
+
+function submitFieldName (fieldname, cb) {
+  submit(multer().none(), 'Content-Disposition: form-data; name="' + fieldname + '"', cb)
+}
+
+describe('Field name decoding', function () {
+  it('should decode an escaped double quote (%22)', function (done) {
+    submitFieldName('a%22b', function (err, req) {
+      assert.ifError(err)
+      assert.deepStrictEqual(Object.keys(req.body), ['a"b'])
+      done()
+    })
+  })
+
+  it('should decode escaped CR and LF (%0D, %0A)', function (done) {
+    submitFieldName('a%0D%0Ab', function (err, req) {
+      assert.ifError(err)
+      assert.deepStrictEqual(Object.keys(req.body), ['a\r\nb'])
+      done()
+    })
+  })
+
+  it('should not alter a field name with no escapes', function (done) {
+    submitFieldName('hello world', function (err, req) {
+      assert.ifError(err)
+      assert.deepStrictEqual(Object.keys(req.body), ['hello world'])
+      done()
+    })
+  })
+
+  it('should preserve a literal percent sign', function (done) {
+    // `%` itself is never escaped by the WHATWG serialiser, so a name like
+    // this must survive untouched -- a full decodeURIComponent would break it.
+    submitFieldName('50%off', function (err, req) {
+      assert.ifError(err)
+      assert.deepStrictEqual(Object.keys(req.body), ['50%off'])
+      done()
+    })
+  })
+
+  it('should accept a file whose field name contains an escaped quote', function (done) {
+    var part = 'Content-Disposition: form-data; name="a%22b"; filename="x.txt"'
+
+    submit(multer().single('a"b'), part, function (err, req) {
+      assert.ifError(err)
+      assert.strictEqual(req.file.fieldname, 'a"b')
+      done()
+    })
+  })
+
+  it('should report the decoded field name on a limit error', function (done) {
+    var opts = { limits: { fieldSize: 1 } }
+    var part = 'Content-Disposition: form-data; name="a%22b"'
+
+    submit(multer(opts).none(), part, function (err) {
+      assert.strictEqual(err.code, 'LIMIT_FIELD_VALUE')
+      assert.strictEqual(err.field, 'a"b')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
`decodeFormDataName` reverses the WHATWG escaping of `%0A`, `%0D` and `%22`, and its own comment says the rule covers "field names and filenames". It was only applied to `filename`. Busboy leaves both escaped, so `req.body` keys, `file.fieldname` and `err.field` all carried the raw escapes.

Measured against the unpatched tree:

```
body keys                        -> ["a%22b"]        expected a"b
upload.single('a"b') + that file -> LIMIT_UNEXPECTED_FILE
originalname                     -> q".txt           already correct
```

So an `<input name='a"b' type=file>` upload is rejected outright, and the only way to accept it was to register the escaped spelling.

`fieldNameSize` now measures the name as it arrived, since decoding shortens it and measuring the decoded form would quietly weaken that limit. `decodeFormDataName` itself is untouched, so the deliberate "never `decodeURIComponent`" property still holds and `50%.pdf` stays intact.

Six new tests, two of which pass before the change as controls (a name with no escapes, and a literal percent sign). The other four fail on the unpatched tree. Each of the two call sites was neutered independently to confirm both are load-bearing.

Suite: 132 passing before, 138 after, 2 pending, no failures either side; `standard` exits 0.

This is the field-name half of #1421, which fixed the filename half.
