### PR TITLE
feat!: enforce default fieldArrayIndexLimit of 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Key | Description | Default
 `fieldSize` | Max number of bytes per field value | `'8KB'`
 `fields` | Max number of fields per request | `1000`
 `fieldNestingDepth` | Max number of nesting levels for field names (e.g. `a[b][c]` has 2 levels) | Infinity
+`fieldArrayIndexLimit` | Max numeric array index accepted inside a field name (e.g. `a[3]` uses index 3) | `1000`
 `fileSize` | Max number of bytes per file | `'8MB'`
 `files` | Max number of files per request | `10`
 `headerPairs` | Max number of header key-value pairs | `2000` (same as Node's http)

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class Multer {
       fieldSize: parseLimit(options.limits || {}, 'fieldSize', '8KB'),
       fields: parseLimit(options.limits || {}, 'fields', 1000),
       fieldNestingDepth: (options.limits || {}).fieldNestingDepth ?? Infinity,
+      fieldArrayIndexLimit: parseLimit(options.limits || {}, 'fieldArrayIndexLimit', 1000),
       fileSize: parseLimit(options.limits || {}, 'fileSize', '8MB'),
       files: parseLimit(options.limits || {}, 'files', 10),
       headerPairs: parseLimit(options.limits || {}, 'headerPairs', 2000)

--- a/lib/error.js
+++ b/lib/error.js
@@ -6,6 +6,7 @@ const errorMessages = new Map([
   ['LIMIT_FIELD_VALUE', 'Field value too long'],
   ['LIMIT_FIELD_COUNT', 'Too many fields'],
   ['LIMIT_FIELD_NESTING', 'Field name nesting too deep'],
+  ['LIMIT_FIELD_ARRAY_INDEX', 'Field name array index too large'],
   ['LIMIT_UNEXPECTED_FILE', 'Unexpected file field']
 ])
 

--- a/lib/read-body.js
+++ b/lib/read-body.js
@@ -13,6 +13,22 @@ import MulterError from './error.js'
 const onFinished = promisify(_onFinished)
 const pipeline = promisify(_pipeline)
 
+// append-field turns a bracket group of digits into an array index, so
+// `a[3]` produces an array of length 4. The index is otherwise unbounded.
+function exceedsArrayIndexLimit (fieldname, limit) {
+  // Names stored as a literal key (e.g. a[6]suffix, [6]) never build an array.
+  if (!/^[^[]+(?:\[[^\]]+\])*(?:\[\])?$/.test(fieldname)) return false
+
+  const pattern = /\[(\d+)\]/g
+  let match
+
+  while ((match = pattern.exec(fieldname)) !== null) {
+    if (Number(match[1]) > limit) return true
+  }
+
+  return false
+}
+
 function drainStream (stream) {
   stream.on('readable', () => {
     while (stream.read() !== null) { /* drain */ }
@@ -38,6 +54,12 @@ function collectFields (busboy, limits) {
       if (limits && Object.hasOwn(limits, 'fieldNestingDepth')) {
         if (fieldname.split('[').length - 1 > limits.fieldNestingDepth) {
           return reject(new MulterError('LIMIT_FIELD_NESTING', fieldname))
+        }
+      }
+
+      if (limits && Object.hasOwn(limits, 'fieldArrayIndexLimit')) {
+        if (exceedsArrayIndexLimit(fieldname, limits.fieldArrayIndexLimit)) {
+          return reject(new MulterError('LIMIT_FIELD_ARRAY_INDEX', fieldname))
         }
       }
 

--- a/test/array-index-limit.js
+++ b/test/array-index-limit.js
@@ -1,0 +1,97 @@
+/* eslint-env mocha */
+
+import assert from 'node:assert'
+
+import FormData from 'form-data'
+
+import * as util from './_util.js'
+import multer from '../index.js'
+
+describe('Field name array index limit', () => {
+  it('should accept an index at the default limit', async () => {
+    const parser = multer().none()
+    const form = new FormData()
+
+    form.append('items[1000]', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body.items[1000], 'value')
+  })
+
+  it('should reject an index above the default limit', async () => {
+    const parser = multer().none()
+    const form = new FormData()
+
+    form.append('items[1001]', 'value')
+
+    await assert.rejects(util.submitForm(parser, form), (err) => {
+      return err.code === 'LIMIT_FIELD_ARRAY_INDEX' && err.field === 'items[1001]'
+    })
+  })
+
+  it('should honor an explicit fieldArrayIndexLimit above the default', async () => {
+    const parser = multer({ limits: { fieldArrayIndexLimit: 2000 } }).none()
+    const form = new FormData()
+
+    form.append('items[1001]', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body.items[1001], 'value')
+  })
+
+  it('should not treat a literal fallback key as an array index', async () => {
+    const parser = multer().none()
+    const form = new FormData()
+
+    form.append('items[1000]tail', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body['items[1000]tail'], 'value')
+  })
+
+  it('should reject an oversized index nested behind object keys', async () => {
+    const parser = multer({ limits: { fieldArrayIndexLimit: 10 } }).none()
+    const form = new FormData()
+
+    form.append('a[b][c][99999]', 'value')
+
+    await assert.rejects(util.submitForm(parser, form), (err) => err.code === 'LIMIT_FIELD_ARRAY_INDEX')
+  })
+
+  it('should allow an index at exactly an explicit limit', async () => {
+    const parser = multer({ limits: { fieldArrayIndexLimit: 5 } }).none()
+    const form = new FormData()
+
+    form.append('a[5]', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body.a.length, 6)
+    assert.strictEqual(req.body.a[5], 'value')
+  })
+
+  it('should leave object keys alone', async () => {
+    const parser = multer({ limits: { fieldArrayIndexLimit: 0 } }).none()
+    const form = new FormData()
+
+    form.append('a[99999999x]', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body.a['99999999x'], 'value')
+  })
+
+  it('should allow a nested array index within the limit', async () => {
+    const parser = multer({ limits: { fieldArrayIndexLimit: 100 } }).none()
+    const form = new FormData()
+
+    form.append('a[b][3]', 'value')
+
+    const req = await util.submitForm(parser, form)
+
+    assert.strictEqual(req.body.a.b[3], 'value')
+  })
+})


### PR DESCRIPTION
Ulises asked for this on v3 in #1461, matching the fieldNestingDepth default in #1433. A name like `items[1000000]` currently builds a huge sparse array even when only one value is sent, so this ports the index check from #1438 and defaults it to 1000.

`items[1000]` still works, `items[1001]` is rejected with `LIMIT_FIELD_ARRAY_INDEX`, and you can raise the limit if you need larger indices. Literal keys such as `items[1000]tail` are left alone.